### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -1,4 +1,6 @@
 name: CI Web
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Abaco-Technol/abaco-loans-analytics/security/code-scanning/2](https://github.com/Abaco-Technol/abaco-loans-analytics/security/code-scanning/2)

To fix the issue, we should explicitly declare a `permissions` block at the root level of the workflow file (just after the `name:` and before the `on:` block), establishing the minimal set of required permissions for the workflow as a whole. In this case, since the workflow only needs to check out code and build/lint, it should be sufficient to grant only `contents: read` access. This addition limits the GitHub Actions `GITHUB_TOKEN` to only reading repository contents, aligning with the principle of least privilege. The change should be made at the root of `.github/workflows/ci-web.yml` by inserting:

```yaml
permissions:
  contents: read
```

immediately after the `name:` entry and before the `on:` block. No additional imports, method definitions, or other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Declare a root-level GitHub Actions permissions block in ci-web workflow granting only contents: read access to the GITHUB_TOKEN.