### PR TITLE
Add integration readiness checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Integraciones disponibles:
 - SonarCloud
 - GitHub Actions
 
+Consulta `docs/integration-readiness.md` para verificar el estado de cada integración y las comprobaciones previas que debes ejecutar antes de usarlas.
+
 ## ContosoTeamStats
 
 This repository contains ContosoTeamStats, a .NET 6 Web API for managing sports teams that ships with Docker, Azure deployment scripts, SendGrid/Twilio integrations, and SQL Server migrations. Follow docs/ContosoTeamStats-setup.md for local setup, secrets, database provisioning, and container validation.

--- a/docs/integration-readiness.md
+++ b/docs/integration-readiness.md
@@ -1,0 +1,31 @@
+# Integration readiness checklist
+
+This repository offers several integrations that require manual configuration before they are operational. Use the checklist below to confirm which services are wired up in your environment and which still need secrets or infrastructure.
+
+## Available integrations
+
+- Azure SQL, Cosmos DB, and Storage for data workloads.
+- Supabase for auth and database hosting.
+- Vercel for the Next.js dashboard deployment.
+- OpenAI, Gemini, and Claude for AI-assisted features.
+- SonarCloud for code quality scanning.
+- GitHub Actions for CI/CD pipelines.
+
+## How to validate each integration
+
+- **Azure SQL / Cosmos / Storage**: ensure connection strings and access keys are present in your environment or key vaults. Run a smoke test against each service (e.g., simple read/write scripts) before promoting changes.
+- **Supabase**: populate the project URL and service role key in your environment variables, then run a basic auth/database query to confirm connectivity. See `docs/supabase-setup.md` for project-specific wiring.
+- **Vercel**: verify the project is connected to the correct GitHub repo and that build secrets are defined. Trigger a preview deployment to confirm builds succeed.
+- **OpenAI / Gemini / Claude**: load the corresponding API keys and run a short completion or embedding request to ensure rate limits and billing are in place.
+- **SonarCloud**: confirm the `sonar-project.properties` matches your organization key and that the token is supplied in CI. Run a local or CI scan to verify analysis completes.
+- **GitHub Actions**: review workflow files under `.github/workflows` (if present) and confirm required secrets are set in the repository. Run the workflows (or `act`) to ensure CI passes.
+
+## Quick environment guard
+
+Before running tooling, you can execute the Deno helper to confirm expected directories exist:
+
+```bash
+deno run --allow-all main.ts
+```
+
+If the script reports missing paths, address them before attempting the integrations above.


### PR DESCRIPTION
## Summary
- add an integration readiness checklist detailing configuration and validation steps for supported services
- reference the new checklist from the main README for quick discovery

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929b622b8dc833398b421a2f248055b)

## Summary by Sourcery

Add an integration readiness checklist document and link it from the main README to help verify configuration of supported services before use.

Documentation:
- Document integration readiness requirements and validation steps for all supported services in a new checklist under docs.
- Reference the integration readiness checklist from the main README for easier discovery.