### PR TITLE
Add integration settings page

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -58,6 +58,9 @@ export default async function Home() {
           <Link href="#products" className={styles.secondaryButton}>
             Explore products
           </Link>
+          <Link href="/settings" className={styles.secondaryButton}>
+            Open settings
+          </Link>
         </div>
         <div className={styles.metrics}>
           {metrics.map((metric) => (

--- a/apps/web/src/app/settings/page.module.css
+++ b/apps/web/src/app/settings/page.module.css
@@ -1,0 +1,268 @@
+/* stylelint-disable csstree/validator */
+:root {
+  --color-bg: #06080f;
+  --color-text-primary: #f3f6fb;
+  --color-text-secondary: rgba(243, 246, 251, 0.72);
+  --color-text-tertiary: rgba(243, 246, 251, 0.7);
+  --color-accent-green: #22c55e;
+  --color-accent-blue: #2563eb;
+  --color-accent-eyebrow: #8fb5ff;
+  --surface-subtle-darker: rgba(255, 255, 255, 0.03);
+  --surface-subtle: rgba(255, 255, 255, 0.04);
+  --surface-interactive: rgba(255, 255, 255, 0.05);
+  --border-subtle: rgba(255, 255, 255, 0.08);
+  --border-interactive: rgba(255, 255, 255, 0.16);
+}
+
+.page {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 20% 20%, color-mix(in srgb, var(--color-accent-blue) 12%, transparent), transparent 30%),
+    radial-gradient(circle at 80% 0%, color-mix(in srgb, var(--color-accent-green) 14%, transparent), transparent 28%),
+    var(--color-bg);
+  color: var(--color-text-primary);
+  padding: 72px 24px 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+.header {
+  max-width: 1120px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.pill {
+  align-self: flex-start;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border-interactive);
+  background: var(--surface-subtle-darker);
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.heroCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 880px;
+}
+
+.eyebrow {
+  color: var(--color-accent-eyebrow);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 13px;
+}
+
+.header h1 {
+  font-size: clamp(32px, 4vw, 44px);
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+}
+
+.header p {
+  color: var(--color-text-secondary);
+  line-height: 1.7;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.primaryButton,
+.secondaryButton,
+.primaryGhost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 18px;
+  border-radius: 12px;
+  font-weight: 600;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.primaryButton {
+  background: linear-gradient(120deg, var(--color-accent-green), var(--color-accent-blue));
+  color: var(--color-bg);
+  box-shadow: 0 20px 40px rgba(37, 99, 235, 0.18);
+}
+
+.secondaryButton {
+  color: var(--color-text-primary);
+  border-color: var(--border-interactive);
+  background: var(--surface-interactive);
+}
+
+.primaryGhost {
+  color: var(--color-text-primary);
+  background: transparent;
+  border-color: #4d4d4d;
+}
+
+.section {
+  max-width: 1120px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.section h2 {
+  font-size: clamp(26px, 3.6vw, 36px);
+}
+
+.sectionCopy {
+  color: var(--color-text-secondary);
+  max-width: 780px;
+  line-height: 1.7;
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  background: var(--surface-subtle);
+  border: 1px solid var(--border-subtle);
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.24);
+}
+
+.cardHeader {
+  display: flex;
+  gap: 14px;
+}
+
+.cardIcon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  background: var(--surface-interactive);
+  border: 1px solid var(--border-interactive);
+  font-size: 22px;
+}
+
+.cardTitleRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.card h3 {
+  font-size: 18px;
+}
+
+.cardCopy {
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.subtleText {
+  color: var(--color-text-tertiary);
+  font-size: 14px;
+}
+
+.statusSuccess {
+  background: rgba(34, 197, 94, 0.16);
+  color: var(--color-accent-green);
+  border: 1px solid rgba(34, 197, 94, 0.32);
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.statusNeutral {
+  background: var(--surface-interactive);
+  color: var(--color-text-primary);
+  border: 1px solid var(--border-interactive);
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.cardActions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.secondaryAction {
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border-interactive);
+  background: transparent;
+  color: var(--color-text-primary);
+}
+
+.guardrailBox {
+  background: var(--surface-subtle);
+  border: 1px solid var(--border-subtle);
+  border-radius: 16px;
+  padding: 20px;
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 18px;
+}
+
+.guardrailBox ul {
+  list-style: disc;
+  padding-left: 18px;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.infoBox {
+  background: var(--surface-interactive);
+  border: 1px solid var(--border-interactive);
+  border-radius: 14px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.infoTitle {
+  font-weight: 700;
+  font-size: 16px;
+}
+
+@media (max-width: 960px) {
+  .guardrailBox {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 56px 18px 72px;
+  }
+
+  .cardHeader {
+    flex-direction: column;
+  }
+}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,0 +1,145 @@
+import Link from 'next/link'
+import styles from './page.module.css'
+
+const integrations = [
+  {
+    name: 'Meta Platform',
+    icon: '📱',
+    description: 'Instagram & Facebook performance with governed token handling.',
+    status: 'Connected',
+    lastSync: '5 minutes ago',
+    cta: 'Sync now',
+    secondary: 'Disconnect',
+    tone: 'success',
+  },
+  {
+    name: 'LinkedIn',
+    icon: '💼',
+    description: 'Company page analytics, follower growth, and engagement KPIs.',
+    status: 'Not connected',
+    lastSync: null,
+    cta: 'Connect LinkedIn',
+    secondary: 'Learn more',
+    tone: 'neutral',
+  },
+  {
+    name: 'Custom Integration',
+    icon: '🔑',
+    description: 'Bring your own API (Codex or internal) with secure token storage.',
+    status: 'Not connected',
+    lastSync: null,
+    cta: 'Configure',
+    secondary: 'View docs',
+    tone: 'neutral',
+  },
+]
+
+const guardrails = [
+  'Tokens are encrypted and never exposed to the client-side app.',
+  'Manual sync keeps existing decks predictable while you pilot new channels.',
+  'Each connector has explicit scopes for only the metrics we display.',
+  'Disconnect immediately revokes stored credentials in Supabase.',
+]
+
+export default function SettingsPage() {
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div className={styles.pill}>Integration Control</div>
+        <div className={styles.heroCopy}>
+          <p className={styles.eyebrow}>Settings</p>
+          <h1>Manage social and custom analytics connectors</h1>
+          <p>
+            Connect Meta, LinkedIn, or a custom Codex endpoint. Validate tokens, trigger manual
+            syncs, and keep your portfolio analytics in step with marketing performance.
+          </p>
+          <div className={styles.actions}>
+            <Link href="/" className={styles.secondaryButton}>
+              Back to home
+            </Link>
+            <Link href="/#analytics" className={styles.primaryGhost}>
+              View analytics
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <section className={styles.section} aria-labelledby="integration-cards">
+        <div className={styles.sectionHeader}>
+          <p className={styles.eyebrow}>Connections</p>
+          <h2 id="integration-cards">Channel status</h2>
+          <p className={styles.sectionCopy}>
+            Use the cards below to validate tokens, trigger manual refreshes, or disconnect
+            channels. Status badges and last-sync timestamps keep teams aligned on freshness.
+          </p>
+        </div>
+
+        <div className={styles.cardGrid}>
+          {integrations.map((integration) => (
+            <article key={integration.name} className={styles.card}>
+              <div className={styles.cardHeader}>
+                <span className={styles.cardIcon} aria-hidden>
+                  {integration.icon}
+                </span>
+                <div>
+                  <div className={styles.cardTitleRow}>
+                    <h3>{integration.name}</h3>
+                    <span
+                      className={
+                        integration.tone === 'success' ? styles.statusSuccess : styles.statusNeutral
+                      }
+                    >
+                      {integration.status}
+                    </span>
+                  </div>
+                  <p className={styles.cardCopy}>{integration.description}</p>
+                  {integration.lastSync ? (
+                    <p className={styles.subtleText}>Last sync: {integration.lastSync}</p>
+                  ) : (
+                    <p className={styles.subtleText}>Not synced yet</p>
+                  )}
+                </div>
+              </div>
+              <div className={styles.cardActions}>
+                <button type="button" className={styles.primaryButton}>
+                  {integration.cta}
+                </button>
+                <button type="button" className={styles.secondaryAction}>
+                  {integration.secondary}
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.section} aria-labelledby="guardrails-heading">
+        <div className={styles.sectionHeader}>
+          <p className={styles.eyebrow}>Governance</p>
+          <h2 id="guardrails-heading">Operational guardrails</h2>
+          <p className={styles.sectionCopy}>
+            A quick reference you can share with marketing, analytics, and compliance teams while
+            the Meta and LinkedIn pilots are underway.
+          </p>
+        </div>
+        <div className={styles.guardrailBox}>
+          <ul>
+            {guardrails.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+          <div className={styles.infoBox}>
+            <p className={styles.infoTitle}>Need Codex details?</p>
+            <p className={styles.subtleText}>
+              Capture the API host, token flow, and event payloads you expect to push so we can wire
+              the connector without blocking other teams.
+            </p>
+            <Link href="/docs" className={styles.primaryGhost}>
+              Open documentation
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a new /settings route that outlines Meta, LinkedIn, and custom connector statuses with manual sync controls
- style the settings view with ABACO theming and governance guidance for sharing with marketing and compliance
- link the landing page hero to the settings experience for quick navigation

## Testing
- `npm run lint` *(fails: existing prettier/type-safety findings in analytics components and utilities)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929c47d55d883338ee6326d2bf3771c)

## Summary by Sourcery

Add a new settings page for managing analytics integrations and link to it from the home page hero.

New Features:
- Introduce a settings route that presents integration status cards for Meta, LinkedIn, and a custom connector with manual sync and connection controls.
- Add a governance section on the settings page outlining integration guardrails and guidance for marketing and compliance stakeholders.
- Link the home page hero section to the new settings experience for quick navigation.

Enhancements:
- Apply dedicated ABACO-themed styling for the new settings page, including responsive layout and visual treatment for cards, actions, and guardrail content.