### PR TITLE
Add Fintech Be Better framework documentation

### DIFF
--- a/docs/Fintech-Be-Better-Framework.md
+++ b/docs/Fintech-Be-Better-Framework.md
@@ -1,0 +1,51 @@
+# Fintech Commercial Intelligence & Engineering Excellence
+
+## Purpose
+The "Be Better" framework unifies commercial outcomes with engineering rigor. It treats the codebase as the product, driving automated growth, auditability, and hyper-strict compliance through a disciplined "Fix, Sync, Commit, Merge" loop augmented by AI agents.
+
+## Macro drivers of engineering hygiene
+- **Velocity vs. risk**: Fintech teams must ship at consumer speed while meeting central-bank-grade reliability; minor defects can trigger losses, censure, and customer distrust.
+- **Technical debt as financial debt**: Debt carries a direct commercial cost—eroding EBITDA and R&D ROI by diverting resources from innovation.
+- **Financial translation**: Engineering metrics must map to business KPIs so leaders can allocate capital based on measurable code health.
+
+## Compliance as a competitive moat
+- Embed GDPR/PCI-DSS/SOC 2/KYC/AML checks inside CI to prove "Security by Design." 
+- Enforce immutable, GPG-signed commits and linear git history for non-repudiation and traceability.
+- Treat passing quality gates as preconditions for partnership approvals and fundraising diligence.
+
+## Engineering ↔ finance correlation matrix
+| Engineering metric | Financial KPI | Economic impact | Tooling |
+| --- | --- | --- | --- |
+| Change Failure Rate (CFR) | Customer churn, brand equity | Incidents degrade trust and raise future CAC | SonarQube quality gates, CodeRabbit review |
+| Technical Debt Ratio (TDR) | EBITDA margin, R&D ROI | High remediation spend lowers yield on engineering capital | Sourcery refactoring, Codex auto-fix |
+| Deployment frequency | Time to Value, revenue velocity | Faster releases unlock pricing and growth experiments | Codex automation, linear git history |
+| Mean Time to Recovery (MTTR) | Transaction volume at risk | Downtime halts revenue in payment/trading flows | CodeRabbit debugging |
+| Code coverage | Operational risk | Untested financial logic increases error probability | SonarQube coverage enforcement |
+
+**TDR formula**: `TDR = (Remediation Cost / Development Cost) × 100`. Target <5% to minimize the "interest" paid on past shortcuts.
+
+## Automated intelligence toolchain
+- **SonarQube**: Custom "Fintech Strict" profile with zero new issues, 100% security hotspot review, <3% duplication, >90% coverage on new code, and cognitive complexity ≤15 per function; gate every PR and fail builds on violations.
+- **Sourcery**: Strict refactoring to reduce nesting, enforce type hints, and require `Decimal` over `float` for currency math; supports custom rules for fintech anti-patterns.
+- **CodeRabbit**: Assertive AI reviews that summarize business impact, challenge architecture, learn from prior reviews, and surface fixes for CI failures to reduce MTTR.
+- **Codex**: Generative automation for CLI workflows and remediation; translates natural language to git/GitHub flows and patches vulnerabilities with parameterized queries or safer patterns.
+
+## Workflow: Fix → Sync → Commit → Merge
+1. **Fix**: Run Sourcery in strict mode for automated refactors before review.
+2. **Sync**: `git pull --rebase origin main` enforces linear history and forces local conflict resolution.
+3. **Commit**: Stage changes and create GPG-signed semantic commits (e.g., `fix(auth): enforce strict JWT validation`).
+4. **Merge**: Use GitHub CLI to create/auto-merge PRs with squash strategy only after SonarQube, CodeRabbit, and CI checks pass.
+
+### Fintech-sync helper
+A shell function (FISP v2.0) encapsulates the loop by running Sourcery, rebasing on `origin/main`, signing commits, force-with-lease pushing, creating PRs with compliance checklists, and enabling auto-merge. It halts on rebase conflicts to protect history integrity.
+
+## Dashboarding for commercial intelligence
+| Panel | Data source | Visualization | Insight → action |
+| --- | --- | --- | --- |
+| Velocity vs. quality | Git deploy rate + SonarQube CFR | Dual-axis line | If CFR rises with velocity, throttle deployments and invest in Codex-driven auto-tests. |
+| Technical debt valuation | SonarQube remediation minutes × avg hourly rate | Big-number currency | If debt exceeds 5% of R&D budget, schedule Sourcery refactoring sprints. |
+| Security posture | SonarQube OWASP + GPG audit logs | Heatmap | Focus assertive reviews and extra human sign-offs on red modules. |
+| Review efficiency | CodeRabbit time-saved + git merge time | Bar | Quantify AI ROI to justify more Codex/Copilot seats. |
+
+## Future outlook
+Agentic DevOps will progress toward self-healing pipelines that auto-repair failing deployments via Codex + SonarQube, and predictive compliance that flags GDPR/PCI risks during ideation. The goal remains market-leading code that is cryptographically verified, automated, and financially intelligent.


### PR DESCRIPTION
## Summary
- add documentation for the "Be Better" fintech commercial intelligence and engineering framework
- outline correlation between engineering metrics and financial KPIs alongside quality toolchain and workflow
- describe dashboarding views and future agentic DevOps outlook

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692aa8393cc083339d6bc7a15b9277df)

## Summary by Sourcery

Documentation:
- Document the Fintech "Be Better" commercial intelligence and engineering framework, correlating engineering metrics with financial KPIs and outlining supporting tooling, workflows, and dashboards.