### PR TITLE
Add markdown export option for analytics

### DIFF
--- a/apps/web/src/components/analytics/ExportControls.tsx
+++ b/apps/web/src/components/analytics/ExportControls.tsx
@@ -29,6 +29,8 @@ function download(name: string, data: string, mime: string) {
 }
 
 export function ExportControls({ analytics }: Props) {
+  const hasLoans = analytics.loans.length > 0
+
   return (
     <section className={styles.section}>
       <div className={styles.sectionHeader}>
@@ -42,6 +44,7 @@ export function ExportControls({ analytics }: Props) {
           className={styles.primaryButton}
           type="button"
           onClick={() => download('analytics.csv', processedAnalyticsToCSV(analytics), 'text/csv')}
+          disabled={!hasLoans}
         >
           Download CSV
         </button>
@@ -51,6 +54,7 @@ export function ExportControls({ analytics }: Props) {
           onClick={() =>
             download('analytics.json', processedAnalyticsToJSON(analytics), 'application/json')
           }
+          disabled={!hasLoans}
         >
           Download JSON
         </button>
@@ -60,6 +64,7 @@ export function ExportControls({ analytics }: Props) {
           onClick={() =>
             download('analytics.md', processedAnalyticsToMarkdown(analytics), 'text/markdown')
           }
+          disabled={!hasLoans}
         >
           Download Markdown
         </button>


### PR DESCRIPTION
## Summary
- add markdown report generator for processed analytics data
- allow export controls to download markdown alongside CSV/JSON
- disable export buttons when no loan data is available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692c69d7efd483339c511073ed90d9e9)

## Summary by Sourcery

Add support for exporting processed analytics as a markdown report and gate all analytics exports on the presence of loan data.

New Features:
- Introduce a markdown report generator for processed analytics data, including KPIs, treemap, roll-rate, and growth projections.
- Expose a new UI control to download analytics as a markdown file alongside existing CSV and JSON exports.

Enhancements:
- Disable all analytics export buttons when no loan data is available to prevent empty downloads.