### PR TITLE
Add financeable wording to presentation summary

### DIFF
--- a/exports/presentation/ABACO_CEO_EXEC_PRESENTATION.md
+++ b/exports/presentation/ABACO_CEO_EXEC_PRESENTATION.md
@@ -1,3 +1,19 @@
 # ABACO CEO Exec Presentation
 
-- **Market TAM (total addressable market) validation (El Salvador, private-sector factoring):** 47,788 formal MSMEs (BCR 2024 dataset: 34,710 micro, 9,881 small, 3,197 medium). Applying average revenues ($60K / $600K / $3.5M) and a 15% receivables factor yields $2,880.1M of outstanding invoices; subtracting $141.0M B2G (business-to-government) exposure (12% PAC 2023 × MIPYME quota) leaves $2,739.1M TAM net. With ~60-day rotation (~6x annually) and 75% eligibility, annualized TAM is ~$12,470M of financeable private-sector invoices.
+- **Market TAM (total addressable market) validation (El Salvador, private-sector factoring):** 47,788 formal MSMEs (micro, small, and medium enterprises; BCR 2024 dataset: 34,710 micro, 9,881 small, 3,197 medium). Applying average revenues ($60K / $600K / $3.5M) and a 15% receivables factor yields ~$2.880B of outstanding invoices; subtracting ~$0.141B B2G (business-to-government) exposure (12% PAC 2023 × MIPYME quota) leaves ~$2.739B TAM net. With ~60-day rotation (~6x annually) and 75% eligibility, annualized TAM is ~$12.470B of financeable private-sector invoices.
+
+## Acronym quick reference
+
+- **AUM:** assets under management
+- **ARPU:** average revenue per user
+- **B2G:** business-to-government
+- **CAC:** customer acquisition cost
+- **DPD:** days past due
+- **KAM:** key account manager
+- **LTV:** lifetime value
+- **MIPYME:** micro, small, and medium enterprise program quota
+- **NPL:** non-performing loan
+- **PAC:** annual procurement plan (Programa Anual de Contrataciones)
+- **STP:** straight-through processing
+- **T2F:** time to funding
+- **TAM:** total addressable market


### PR DESCRIPTION
## Summary
- add a CEO presentation markdown bullet clarifying the TAM narrative and using the corrected "financeable" spelling
- expand the TAM acronym and define B2G to address terminology feedback

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692cb5a570ec8321a8a670dfb27193d3)

## Summary by Sourcery

Documentation:
- Document the CEO executive presentation with clarified TAM terminology, expanded acronyms, and corrected financeable wording.