### PR TITLE
Fix Azure KPI blob export typing for Python 3.9

### DIFF
--- a/apps/analytics/src/enterprise_analytics_engine.py
+++ b/apps/analytics/src/enterprise_analytics_engine.py
@@ -1,11 +1,11 @@
 import pandas as pd
 import numpy as np
-from typing import Dict, Protocol, runtime_checkable
+from typing import Dict, Optional, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class KPIExporter(Protocol):
-    def upload_metrics(self, metrics: Dict[str, float], blob_name: str | None = None) -> str:
+    def upload_metrics(self, metrics: Dict[str, float], blob_name: Optional[str] = None) -> str:
         ...
 
 class LoanAnalyticsEngine:
@@ -90,7 +90,7 @@ class LoanAnalyticsEngine:
         }
 
     def export_kpis_to_blob(
-        self, exporter: KPIExporter, blob_name: str | None = None
+        self, exporter: KPIExporter, blob_name: Optional[str] = None
     ) -> str:
         kpis = self.run_full_analysis()
         return exporter.upload_metrics(kpis, blob_name=blob_name)


### PR DESCRIPTION
## Summary
- replace PEP 604 union annotations in the KPI export helper with Optional to preserve Python 3.9 compatibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cfefbb7b083318b5379951a5292bb)

## Summary by Sourcery

Enhancements:
- Replace PEP 604 union type annotations in KPI export interfaces with Optional-based annotations compatible with Python 3.9.