### PR TITLE
Ensure SonarCloud workflow keeps PR permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   sonarcloud:
     name: SonarCloud Scan
+    # Explicit permissions are required so the SonarCloud action can read PR metadata
+    # and publish decorations/check runs. The defaults are overridden when a block is
+    # present, so ensure the token retains the scopes it needs.
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Summary
- clarify SonarCloud workflow permissions to preserve PR metadata access and decoration scopes

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cf3b7e31083318851bcd1aaacd6e3)

## Summary by Sourcery

CI:
- Set explicit contents and pull-requests read permissions on the SonarCloud GitHub Actions job to retain necessary PR metadata and check run access.