### PR TITLE
Fix Optional typing for blob export compatibility

### DIFF
--- a/apps/analytics/src/enterprise_analytics_engine.py
+++ b/apps/analytics/src/enterprise_analytics_engine.py
@@ -1,11 +1,11 @@
 import pandas as pd
 import numpy as np
-from typing import Dict, Protocol, runtime_checkable
+from typing import Dict, Optional, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class KPIExporter(Protocol):
-    def upload_metrics(self, metrics: Dict[str, float], blob_name: str | None = None) -> str:
+    def upload_metrics(self, metrics: Dict[str, float], blob_name: Optional[str] = None) -> str:
         ...
 
 class LoanAnalyticsEngine:
@@ -90,7 +90,7 @@ class LoanAnalyticsEngine:
         }
 
     def export_kpis_to_blob(
-        self, exporter: KPIExporter, blob_name: str | None = None
+        self, exporter: KPIExporter, blob_name: Optional[str] = None
     ) -> str:
         kpis = self.run_full_analysis()
         return exporter.upload_metrics(kpis, blob_name=blob_name)


### PR DESCRIPTION
## Summary
- replace PEP604-style union annotations in enterprise analytics export helpers with Optional for Python 3.9 compatibility
- keep KPI exporter protocol and blob export helper importable on configured runtime

## Testing
- python -m pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cf3d864d4833192765a45b1bcee8a)

## Summary by Sourcery

Enhancements:
- Replace PEP 604-style union annotations with Optional in KPI exporter protocol and blob export method signatures for Python 3.9 compatibility.