### PR TITLE
Configure Dependabot reviewers and assignee

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
+
 updates:
-  - package-ecosystem: "npm"
+  - &default_settings
+    package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -14,28 +16,9 @@ updates:
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+  - <<: *default_settings
+    package-ecosystem: "pip"
     open-pull-requests-limit: 10
-    assignees:
-      - "codex"
-    reviewers:
-      - "sonarqube"
-      - "coderabbit"
-      - "sourcery"
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+  - <<: *default_settings
+    package-ecosystem: "github-actions"
     open-pull-requests-limit: 5
-    assignees:
-      - "codex"
-    reviewers:
-      - "sonarqube"
-      - "coderabbit"
-      - "sourcery"


### PR DESCRIPTION
## Summary
- add default assignee codex for Dependabot PRs
- request reviews from sonarqube, coderabbit, and sourcery on automated updates

## Testing
- not run (config change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d37da30508321be94c649b0b19799)

## Summary by Sourcery

Configure Dependabot to automatically assign and request reviews for its pull requests.

Chores:
- Set Codex as the default assignee for all Dependabot-generated pull requests.
- Request reviews from SonarQube, CodeRabbit, and Sourcery on Dependabot update pull requests across all configured package ecosystems.