### PR TITLE
Trim bulk token input before parsing

### DIFF
--- a/apps/web/src/components/integrations/BulkTokenInput.tsx
+++ b/apps/web/src/components/integrations/BulkTokenInput.tsx
@@ -28,7 +28,7 @@ export function BulkTokenInput({ open, onClose, onProcessItem }: BulkTokenInputP
   const [processing, setProcessing] = useState(false)
   const [summary, setSummary] = useState<string>('')
 
-  const parsedItems = useMemo(() => parseInput(rawInput), [rawInput])
+  const parsedItems = useMemo(() => parseInput(rawInput.trim()), [rawInput])
 
   const updateItem = useCallback((index: number, changes: Partial<BulkTokenItem>) => {
     setItems((current) =>


### PR DESCRIPTION
## Summary
- trim whitespace from the bulk token input before parsing so formatting issues do not create spurious entries

## Testing
- npm run lint -- src/components/integrations/BulkTokenInput.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692e3609d7848330a81468731243603d)

## Summary by Sourcery

Bug Fixes:
- Prevent leading and trailing whitespace in bulk token input from producing spurious parsed items.