### PR TITLE
fix: disable require-await lint for next.config.ts

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: __dirname,
   },
+  // eslint-disable-next-line @typescript-eslint/require-await
   headers: async () => [
     {
       source: '/:path*',
@@ -31,7 +32,9 @@ const nextConfig: NextConfig = {
       ],
     },
   ],
+  // eslint-disable-next-line @typescript-eslint/require-await
   redirects: async () => [],
+  // eslint-disable-next-line @typescript-eslint/require-await
   rewrites: async () => ({
     beforeFiles: [],
     afterFiles: [],


### PR DESCRIPTION
## Summary
- suppress the require-await lint rule for async Next.js configuration hooks
- keep headers, redirects, and rewrites async as required by the framework

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692e61b30c8083308c5a4fa7e26a3685)

## Summary by Sourcery

Bug Fixes:
- Prevent ESLint require-await violations for async headers, redirects, and rewrites configuration hooks in Next.js.