### PR TITLE
Add package initializers for analytics modules

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Monorepo apps namespace for web and analytics modules."""

--- a/apps/analytics/__init__.py
+++ b/apps/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Analytics app namespace exposing KPI and risk intelligence components."""

--- a/apps/analytics/src/__init__.py
+++ b/apps/analytics/src/__init__.py
@@ -1,0 +1,1 @@
+"""Source package for enterprise analytics engines and supporting utilities."""

--- a/apps/analytics/tests/__init__.py
+++ b/apps/analytics/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for analytics KPIs, quality gates, and risk logic."""


### PR DESCRIPTION
## Summary
- add package initializers across apps and analytics directories to enable clean module imports
- ensure analytics KPI engine tests resolve package paths without ModuleNotFound errors

## Testing
- pytest apps/analytics/tests/test_enterprise_analytics_engine.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0eb90438833187af38f3b7c9b88f)

## Summary by Sourcery

Add package initializers to establish proper Python package namespaces for the apps and analytics modules.

Enhancements:
- Introduce __init__ modules for apps and analytics directories to formalize package structure and support clean imports.

Tests:
- Ensure analytics KPI engine tests can import analytics modules without ModuleNotFound errors by leveraging the new package initializers.