### PR TITLE
Fix KPI export type hints for Python 3.9 compatibility

### DIFF
--- a/apps/analytics/src/enterprise_analytics_engine.py
+++ b/apps/analytics/src/enterprise_analytics_engine.py
@@ -1,11 +1,11 @@
 import pandas as pd
 import numpy as np
-from typing import Dict, Protocol, runtime_checkable
+from typing import Dict, Optional, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class KPIExporter(Protocol):
-    def upload_metrics(self, metrics: Dict[str, float], blob_name: str | None = None) -> str:
+    def upload_metrics(self, metrics: Dict[str, float], blob_name: Optional[str] = None) -> str:
         ...
 
 class LoanAnalyticsEngine:
@@ -90,7 +90,7 @@ class LoanAnalyticsEngine:
         }
 
     def export_kpis_to_blob(
-        self, exporter: KPIExporter, blob_name: str | None = None
+        self, exporter: KPIExporter, blob_name: Optional[str] = None
     ) -> str:
         kpis = self.run_full_analysis()
         return exporter.upload_metrics(kpis, blob_name=blob_name)


### PR DESCRIPTION
## Summary
- ensure KPI exporter and export helper type hints remain compatible with Python 3.9 by using Optional annotations
- (from previous changes) add Azure Blob exporter to publish loan analytics KPIs with default Azure credentials support
- (from previous changes) expose LoanAnalyticsEngine helpers to build from dictionaries and export results via the blob exporter

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cf3c72ba88331bd5a81f91d85cb63)

## Summary by Sourcery

Bug Fixes:
- Fix type annotations on KPI exporter interfaces to avoid use of Python 3.10 union syntax and restore compatibility with Python 3.9.