### PR TITLE
Add utility to report GitHub PR status

### DIFF
--- a/scripts/pr_status.py
+++ b/scripts/pr_status.py
@@ -67,10 +67,10 @@ def summarize_statuses(statuses: List[Dict], state: str) -> str:
     if not statuses:
         return f"Combined state: {state or 'unknown'} (no individual statuses)."
     lines = [f"Combined state: {state or 'unknown'}"]
-    for status in sorted(statuses, key=lambda s: s.get("context", "")):
-        lines.append(
-            f"- {status.get('context')}: {status.get('state')} (url={status.get('target_url')})"
-        )
+    lines.extend(
+        f"- {status.get('context')}: {status.get('state')} (url={status.get('target_url')})"
+        for status in sorted(statuses, key=lambda s: s.get("context", ""))
+    )
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary
- add a reusable script to fetch pull request mergeability, check runs, and commit statuses from GitHub
- support authenticated API usage via GITHUB_TOKEN/GH_TOKEN with concise reporting output

## Testing
- python -m compileall scripts/pr_status.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fba3b98b08331a4c0a9cbf5ecb533)

## Summary by Sourcery

New Features:
- Introduce a reusable pr_status.py script to query GitHub for a pull request’s details, mergeability, check runs, and commit statuses, with optional token-based authentication.