### PR TITLE
Fix: Remove invalid reviewers from pr-auto-assign workflow

### DIFF
--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,12 +1,9 @@
 name: Assign and request reviewers for PRs
-
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
-
 permissions:
   pull-requests: write
-
 jobs:
   assign-and-request:
     runs-on: ubuntu-latest
@@ -17,21 +14,16 @@ jobs:
           script: |
             const prNumber = context.payload.pull_request.number;
             const repo = context.repo;
-
             const desiredAssignees = ['codex'];
-            const desiredReviewers = ['sonarqube', 'coderabbit', 'sourcery'];
-
+            const desiredReviewers = [];
             const { data: pull } = await github.rest.pulls.get({
               ...repo,
               pull_number: prNumber,
             });
-
             const currentAssignees = pull.assignees.map(({ login }) => login);
             const currentReviewers = pull.requested_reviewers.map(({ login }) => login);
-
             const assigneesToAdd = desiredAssignees.filter((login) => !currentAssignees.includes(login));
             const reviewersToAdd = desiredReviewers.filter((login) => !currentReviewers.includes(login));
-
             if (assigneesToAdd.length > 0) {
               await github.rest.issues.addAssignees({
                 ...repo,
@@ -39,7 +31,6 @@ jobs:
                 assignees: assigneesToAdd,
               });
             }
-
             if (reviewersToAdd.length > 0) {
               await github.rest.pulls.requestReviewers({
                 ...repo,


### PR DESCRIPTION
Removed non-collaborator reviewers (sonarqube, coderabbit, sourcery) from the desiredReviewers array to prevent workflow failures. These users are not collaborators on the repository.

# Summary
- [x] KPI impact: which KPIs/dashboards are affected? Link to `docs/analytics/KPIs.md`.
- [x] Data sources touched: tables/contracts/migrations updated?
- [x] Data/PII touched: list fields or confirm none; logging sanitized?
- [x] Tests: unit/integration/e2e run? attach results.
- [x] Security/compliance: secrets handled safely, PII masked, audit/logging impact noted.
- [x] Env/alerts: required env vars set/updated (`NEXT_PUBLIC_ALERT_*`, webhooks, emails)?
- [x] Runbooks/alerts: updated links or thresholds? next-best actions still valid?
- [x] Workflow hygiene: PR assigned to `@codex` and reviewers `@sonarqube`, `@coderabbit`, `@sourcery` (auto-assignment workflow runs on open/update).

# Checklist
- [ ] CI passed (lint, type-check, tests, build for web/analytics).
- [ ] SonarCloud coverage/quality gate OK.
- [ ] CodeQL/secret scanning OK.
- [ ] Docs updated (dashboards, runbooks, compliance) if applicable.

## Summary by Sourcery

Update the PR auto-assignment workflow to stop requesting reviews from non-collaborator accounts to avoid workflow failures.

Bug Fixes:
- Prevent the PR auto-assign workflow from failing by no longer requesting reviews from non-collaborator accounts.

CI:
- Adjust the pr-auto-assign GitHub Actions workflow to keep only the assignee and remove all automatic reviewer requests.