### PR TITLE
Improve numeric ingestion robustness

### DIFF
--- a/streamlit_ingestion.py
+++ b/streamlit_ingestion.py
@@ -1,0 +1,46 @@
+"""Reusable ingestion utilities for the Streamlit app."""
+
+import re
+from typing import Set
+
+import numpy as np
+import pandas as pd
+
+
+def normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
+    clean = (
+        df.rename(
+            columns=lambda col: re.sub(r"[^a-z0-9_]", "_", re.sub(r"\s+", "_", col.strip().lower()))
+        )
+        .pipe(lambda d: d.loc[:, ~d.columns.duplicated()])
+    )
+    return clean
+
+
+def safe_numeric(series: pd.Series) -> pd.Series:
+    cleaned = (
+        series.astype(str)
+        .str.replace(r"[₡$€,,%]", "", regex=True)
+        .str.replace(",", "", regex=False)
+        .replace("", np.nan)
+    )
+    return pd.to_numeric(cleaned, errors="coerce")
+
+
+def coerce_numeric_columns(df: pd.DataFrame, required_numeric: Set[str]) -> pd.DataFrame:
+    """Convert required numeric columns to numeric and coerce optional numeric-like fields."""
+
+    payload = df.copy()
+    object_columns = set(payload.select_dtypes(include=["object"]).columns)
+
+    for col in object_columns:
+        converted = safe_numeric(payload[col])
+        if col in required_numeric or converted.notna().sum() > 0:
+            payload[col] = converted
+
+    for col in required_numeric - object_columns:
+        if col in payload.columns:
+            payload[col] = safe_numeric(payload[col])
+
+    return payload
+

--- a/tests/test_numeric_coercion.py
+++ b/tests/test_numeric_coercion.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from pandas.api import types as ptypes
+
+from streamlit_ingestion import coerce_numeric_columns
+
+
+REQUIRED_NUMERIC_COLUMNS = {
+    "loan_amount",
+    "appraised_value",
+    "borrower_income",
+    "monthly_debt",
+    "interest_rate",
+    "principal_balance",
+}
+
+
+def test_required_numeric_columns_coerced_when_blank():
+    df = pd.DataFrame({"loan_amount": ["", " "]})
+
+    coerced = coerce_numeric_columns(df, REQUIRED_NUMERIC_COLUMNS)
+
+    assert ptypes.is_numeric_dtype(coerced["loan_amount"])
+    assert coerced["loan_amount"].isna().all()
+
+
+def test_optional_object_columns_only_coerced_when_numeric_values_present():
+    df = pd.DataFrame({"notes": ["abc", ""], "other_metric": ["10", ""]})
+
+    coerced = coerce_numeric_columns(df, REQUIRED_NUMERIC_COLUMNS)
+
+    assert coerced["notes"].dtype == object
+    assert ptypes.is_numeric_dtype(coerced["other_metric"])


### PR DESCRIPTION
## Summary
- extract ingestion helpers into a shared module to reuse normalization and numeric coercion
- ensure required numeric upload fields are coerced even when empty and add coverage for optional numeric-like columns
- add focused tests covering numeric coercion behavior for uploads with blanks

## Testing
- python -m pytest tests/test_numeric_coercion.py
- python -m compileall streamlit_ingestion.py streamlit_app.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6930f8e7a7108333b110fe756ab9cdde)

## Summary by Sourcery

Extract shared ingestion utilities and improve robustness of numeric field coercion for uploaded loan datasets.

New Features:
- Introduce a reusable ingestion module that centralizes column normalization and numeric coercion helpers.

Bug Fixes:
- Ensure required numeric upload columns are coerced to numeric types even when values are blank or missing.
- Avoid unintentionally coercing non-numeric text columns unless they contain numeric-like values.

Enhancements:
- Refactor the Streamlit app to use shared ingestion helpers and a single source of truth for required numeric columns.

Tests:
- Add focused tests verifying coercion of required numeric columns with blank values and conditional coercion of optional object columns.