### PR TITLE
Resolve merge conflicts and refresh analytics apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@ ABACO delivers an executive-grade analytics and governance stack for lending tea
 - **apps/analytics**: Python scoring, stress testing, and KPI pipelines.
 - **infra/azure**: Azure infra-as-code and deployment scripts.
 - **data_samples**: Anonymized datasets for repeatable development and testing.
-<<<<<<< Updated upstream
-=======
 - **Integrations**: Figma / Notion / Slack setup guide at `docs/integrations.md` (see `docs/integration-readiness.md` for service checks).
->>>>>>> Stashed changes
 
 ## Observability, KPIs, and lineage
 - **KPI catalog**: Use `docs/KPI-Operating-Model.md` to define owners, formulas, and lineage links for every metric; keep PR and issue references for auditability.

--- a/apps/analytics/src/azure_blob_exporter.py
+++ b/apps/analytics/src/azure_blob_exporter.py
@@ -40,12 +40,8 @@ class AzureBlobKPIExporter:
         if not isinstance(metrics, dict) or not metrics:
             raise ValueError("Metrics payload must be a non-empty dictionary.")
 
-<<<<<<< HEAD
         if blob_name is not None and not isinstance(blob_name, str):
             raise ValueError("blob_name must be a string if provided.")
-
-=======
->>>>>>> origin/main
         normalized_metrics: Dict[str, float] = {}
         for key, value in metrics.items():
             if not isinstance(key, str) or not key.strip():

--- a/apps/analytics/src/enterprise_analytics_engine.py
+++ b/apps/analytics/src/enterprise_analytics_engine.py
@@ -1,16 +1,12 @@
 import numpy as np
-<<<<<<< HEAD
-from typing import Dict, Optional, Protocol, runtime_checkable
+import pandas as pd
+from typing import Dict, List, Optional, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class KPIExporter(Protocol):
     def upload_metrics(self, metrics: Dict[str, float], blob_name: Optional[str] = None) -> str:
         ...
-=======
-import pandas as pd
-from typing import Dict, List
->>>>>>> origin/main
 
 class LoanAnalyticsEngine:
     """

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,14 +8,10 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
-<<<<<<< HEAD
-        "@supabase/supabase-js": "^2.85.0",
-=======
         "@supabase/ssr": "^0.8.0",
-        "@supabase/supabase-js": "^2.48.0",
+        "@supabase/supabase-js": "^2.85.0",
         "@vercel/analytics": "^1.6.0",
         "@vercel/speed-insights": "^1.3.0",
->>>>>>> origin/main
         "next": "^16.0.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -3615,7 +3611,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4059,8 +4054,6 @@
       "dev": true,
       "license": "MIT"
     },
-<<<<<<< HEAD
-=======
     "node_modules/@sindresorhus/is": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.1.1.tgz",
@@ -4091,7 +4084,6 @@
       "integrity": "sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA==",
       "license": "CC0-1.0"
     },
->>>>>>> origin/main
     "node_modules/@supabase/auth-js": {
       "version": "2.86.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.86.0.tgz",
@@ -4143,8 +4135,6 @@
         "node": ">=20.0.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/@supabase/ssr": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.8.0.tgz",
@@ -4157,7 +4147,6 @@
         "@supabase/supabase-js": "^2.76.1"
       }
     },
->>>>>>> origin/main
     "node_modules/@supabase/storage-js": {
       "version": "2.86.0",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.86.0.tgz",
@@ -4176,10 +4165,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.86.0.tgz",
       "integrity": "sha512-BaC9sv5+HGNy1ulZwY8/Ev7EjfYYmWD4fOMw9bDBqTawEj6JHAiOHeTwXLRzVaeSay4p17xYLN2NSCoGgXMQnw==",
       "license": "MIT",
-<<<<<<< HEAD
-=======
-      "peer": true,
->>>>>>> origin/main
       "dependencies": {
         "@supabase/auth-js": "2.86.0",
         "@supabase/functions-js": "2.86.0",
@@ -4570,15 +4555,12 @@
         "undici-types": "~6.21.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/@types/parse-path": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
       "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
       "license": "MIT"
     },
->>>>>>> origin/main
     "node_modules/@types/phoenix": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
@@ -4605,15 +4587,12 @@
         "@types/react": "^19.2.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "license": "MIT"
     },
->>>>>>> origin/main
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -5514,7 +5493,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz",
       "integrity": "sha512-PUgKp2rn8fFsI++lF2sO7gwO2d9Yj57Utr5yEsDf3GNaQcowCLKL7sf+LvVFvtJDXUp/03+dC6f2+LCv5aK1ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/compiler-core": "3.5.25",
@@ -9059,8 +9037,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -9125,7 +9101,6 @@
         "node": ">=16.17.0"
       }
     },
->>>>>>> origin/main
     "node_modules/iceberg-js": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.0.tgz",
@@ -9135,8 +9110,6 @@
         "node": ">=20.0.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9169,7 +9142,6 @@
       ],
       "license": "BSD-3-Clause"
     },
->>>>>>> origin/main
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -10115,7 +10087,6 @@
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "devOptional": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -10147,7 +10118,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10168,7 +10138,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10189,7 +10158,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10210,7 +10178,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10231,7 +10198,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10252,7 +10218,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10273,7 +10238,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10294,7 +10258,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10315,7 +10278,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10336,7 +10298,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10357,7 +10318,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10824,7 +10784,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.0.3.tgz",
       "integrity": "sha512-Ka0/iNBblPFcIubTA1Jjh6gvwqfjrGq1Y2MTI5lbjeLIAfmC+p5bQmojpRZqgHHVu5cG4+qdIiwXiBSm/8lZ3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.0.3",
         "@swc/helpers": "0.5.15",
@@ -11186,7 +11145,6 @@
       "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.2.1.tgz",
       "integrity": "sha512-OE5ONizgwkKhjTGlUYB3ksE+2q2/I30QIYFl3N1yYz1r2rwhunGA3puUvqkzXwgLQ3AdsNcigPDmyQsqjbSdoQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dxup/nuxt": "^0.2.1",
         "@nuxt/cli": "^3.30.0",
@@ -11557,7 +11515,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -13930,7 +13887,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -14782,7 +14738,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.6.tgz",
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -15146,7 +15101,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15165,7 +15119,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",
@@ -15349,8 +15302,6 @@
         "node": ">=0.10.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -15439,7 +15390,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
->>>>>>> origin/main
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -15461,8 +15411,6 @@
         }
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/wsl-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
@@ -15487,7 +15435,6 @@
         "node": ">=10"
       }
     },
->>>>>>> origin/main
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",

--- a/apps/web/src/app/data.ts
+++ b/apps/web/src/app/data.ts
@@ -1,22 +1,3 @@
-<<<<<<< HEAD
-export type Metric = {
-  label: string
-  value: string
-}
-
-export type Product = {
-  title: string
-  detail: string
-}
-
-export type Step = {
-  label: string
-  title: string
-  copy: string
-}
-
-export const metrics: Metric[] = [
-=======
 export type Metric = Readonly<{
   label: string
   value: string
@@ -33,25 +14,13 @@ export type Step = Readonly<{
   copy: string
 }>
 
-<<<<<<< HEAD
-export const metrics = [
-=======
 export const metrics: ReadonlyArray<Metric> = [
->>>>>>> origin/main
   { label: 'Approval uplift with governed risk', value: '+18%' },
   { label: 'Reduction in manual reviews', value: '42%' },
   { label: 'Portfolio coverage with audit trails', value: '100%' },
 ] as const satisfies readonly Metric[]
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-export const products = [
-=======
-export const products: Product[] = [
->>>>>>> upstream/main
-=======
 export const products: ReadonlyArray<Product> = [
->>>>>>> origin/main
   {
     title: 'Portfolio Intelligence',
     detail:
@@ -69,29 +38,13 @@ export const products: ReadonlyArray<Product> = [
   },
 ] as const satisfies readonly Product[]
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-export const controls = [
-=======
-export const controls: string[] = [
->>>>>>> upstream/main
-=======
 export const controls: ReadonlyArray<string> = [
->>>>>>> origin/main
   'Segregated roles, approvals, and immutable audit logs for every change.',
   'Real-time monitoring of SLAs, risk thresholds, and operational KPIs.',
   'Encryption by default with least-privilege access across environments.',
 ] as const satisfies readonly string[]
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-export const steps = [
-=======
-export const steps: Step[] = [
->>>>>>> upstream/main
-=======
 export const steps: ReadonlyArray<Step> = [
->>>>>>> origin/main
   {
     label: '01',
     title: 'Unify data signals',

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,17 +1,8 @@
-<<<<<<< HEAD
-import './globals.css'
-
-import { siteMetadata } from './seo'
-
-export const metadata = siteMetadata
-=======
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
-<<<<<<< HEAD
-=======
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
->>>>>>> origin/main
+
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -20,7 +11,6 @@ export const metadata: Metadata = {
   title: 'Abaco Loans Analytics',
   description: 'Customer-centric lending intelligence with governed growth for Abaco clients.',
 }
->>>>>>> origin/main
 
 export default function RootLayout({
   children,
@@ -28,26 +18,12 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-<<<<<<< HEAD
-    <html lang="en">
-<<<<<<< HEAD
-      <body>
-        <a className="skipLink" href="#main-content">
-          Skip to main content
-        </a>
-        {children}
-=======
-      <body className={inter.className}>{children}</body>
->>>>>>> upstream/main
-=======
     <html lang="en" className={inter.className}>
       <body>
         {children}
         <Analytics />
         <SpeedInsights />
->>>>>>> origin/main
       </body>
->>>>>>> origin/main
     </html>
   )
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,11 +1,8 @@
-<<<<<<< HEAD
-import Link from 'next/link'
-import { controls, metrics, products, steps } from './data'
-import styles from './page.module.css'
-=======
 import type { PostgrestSingleResponse } from '@supabase/supabase-js'
 import Link from 'next/link'
-import { z } from 'zod'
+
+import { AnalyticsDashboard } from '@/components/analytics/AnalyticsDashboard'
+
 import {
   controls as fallbackControls,
   metrics as fallbackMetrics,
@@ -13,93 +10,8 @@ import {
   steps as fallbackSteps,
 } from './data'
 import styles from './page.module.css'
-<<<<<<< HEAD
 import { isSupabaseConfigured, supabase } from '../lib/supabaseClient'
-import { logLandingPageDiagnostic } from '../lib/landingPageDiagnostics'
-import {
-  EMPTY_LANDING_PAGE_DATA,
-  landingPageDataSchema,
-  type LandingPageData,
-  type Metric,
-  type Product,
-  type Step,
-} from '../types/landingPage'
-
-async function getData(): Promise<LandingPageData> {
-  if (!supabase || !isSupabaseConfigured) {
-    logLandingPageDiagnostic({
-      status: 'missing-config',
-      supabaseConfigured: false,
-      payload: EMPTY_LANDING_PAGE_DATA,
-    })
-    console.warn('Supabase environment variables are missing; using fallback landing page data')
-    return EMPTY_LANDING_PAGE_DATA
-  }
-
-  const { data, error } = await supabase.from('landing_page_data').select('*').single()
-
-  if (error) {
-    logLandingPageDiagnostic({
-      status: 'fetch-error',
-      supabaseConfigured: true,
-      error,
-      payload: EMPTY_LANDING_PAGE_DATA,
-    })
-    console.error('Error fetching landing page data:', error)
-    return EMPTY_LANDING_PAGE_DATA
-  }
-
-  if (!data) {
-    logLandingPageDiagnostic({
-      status: 'no-data',
-      supabaseConfigured: true,
-      payload: EMPTY_LANDING_PAGE_DATA,
-    })
-    console.error('Landing page data is missing from Supabase response')
-    return EMPTY_LANDING_PAGE_DATA
-  }
-
-  const parsed = landingPageDataSchema.safeParse(data)
-
-  if (!parsed.success) {
-    logLandingPageDiagnostic({
-      status: 'invalid-shape',
-      supabaseConfigured: true,
-      error: parsed.error.flatten(),
-      payload: EMPTY_LANDING_PAGE_DATA,
-    })
-    console.error('Invalid landing page data shape from Supabase:', parsed.error.flatten())
-    return EMPTY_LANDING_PAGE_DATA
-  }
-
-  logLandingPageDiagnostic({
-    status: 'ok',
-    supabaseConfigured: true,
-    payload: parsed.data,
-  })
-=======
-import { supabase } from '../lib/supabaseClient'
-import type { LandingPageData } from '../types/landingPage'
-import { AnalyticsDashboard } from '@/components/analytics/AnalyticsDashboard'
-
-<<<<<<< HEAD
-type Metric = {
-  label: string
-  value: string
-  helper?: string
-}
-
-type Product = {
-  title: string
-  detail: string
-  kicker?: string
-}
-
-type Step = {
-  label: string
-  title: string
-  copy: string
-}
+import { landingPageDataSchema, type LandingPageData } from '../types/landingPage'
 
 const navLinks = [
   { label: 'KPIs', href: '#kpis' },
@@ -109,420 +21,165 @@ const navLinks = [
   { label: 'Playbook', href: '#demo' },
 ]
 
-const metrics: Metric[] = [
-  {
-    label: 'Approval uplift with governed risk',
-    value: '+18%',
-    helper: 'Quarter-over-quarter across prime and near-prime',
-  },
-  {
-    label: 'Reduction in manual reviews',
-    value: '42%',
-    helper: 'Workflow automation with auditability',
-  },
-  {
-    label: 'Portfolio coverage with audit trails',
-    value: '100%',
-    helper: 'Evidence mapped to every decision',
-  },
-]
-
-const scorecards: Metric[] = [
-  {
-    label: 'Application-to-cash velocity',
-    value: '< 48 hours',
-    helper: 'From lead to funded drawdown',
-  },
-  {
-    label: 'Loss-forecast confidence',
-    value: '97%',
-    helper: 'Back-tested across six vintages with challenger policies',
-  },
-  {
-    label: 'Straight-through processing',
-    value: '70%',
-    helper: 'Decisions cleared with controls and service-level guardrails',
-  },
-]
-
-const products: Product[] = [
-  {
-    title: 'Portfolio Intelligence',
-    detail: 'Daily performance lenses across cohorts, pricing, liquidity, and partner flows.',
-    kicker: 'Capital efficiency, reserve discipline, and covenant readiness.',
-  },
-  {
-    title: 'Risk Orchestration',
-    detail:
-      'Dynamic policy controls, challenger experiments, and guardrails to defend credit quality.',
-    kicker: 'Segregation of duties with sign-offs and immutable change logs.',
-  },
-  {
-    title: 'Growth Enablement',
-    detail:
-      'Pre-approved journeys, partner-ready APIs, and data rooms that accelerate funding decisions.',
-    kicker: 'Unified evidence packs for investors, auditors, and strategic partners.',
-  },
-]
-
-const dashboards: Product[] = [
-  {
-    title: 'Liquidity & funding cockpit',
-    detail: 'Covenant monitoring, cash runway, and facility utilization in one governed console.',
-    kicker: '99.4% SLA adherence with automated alerts and playbooks.',
-  },
-  {
-    title: 'Collections intelligence',
-    detail: 'Roll rate, cure, and recovery tracking with interventions ranked by ROI.',
-    kicker: 'Targeted outreach cadences backed by performance data.',
-  },
-  {
-    title: 'Product P&L lenses',
-    detail: 'Unit economics by channel, geography, and risk appetite with drilldowns on variance.',
-    kicker: 'Benchmark-ready narratives for executive and board reviews.',
-  },
-]
-
-const controls = [
-  'Segregated roles, approvals, and immutable audit logs for every change.',
-  'Real-time monitoring of SLAs, risk thresholds, and operational KPIs.',
-  'Encryption by default with least-privilege access across environments.',
-  'Continuous evidence packs for regulators, investors, and funding partners.',
-]
-
-const steps: Step[] = [
-  {
-    label: '01',
-    title: 'Unify data signals',
-    copy: 'Blend credit bureau, behavioral, and operational streams to build a trusted lending graph.',
-  },
-  {
-    label: '02',
-    title: 'Model & decide',
-    copy: 'Score applicants with explainable risk layers and adaptive policies aligned to appetite.',
-  },
-  {
-    label: '03',
-    title: 'Measure & learn',
-    copy: 'Track outcomes against revenue and risk KPIs, iterating with governed experiment loops.',
-  },
-]
-
-const structuredData = {
-  '@context': 'https://schema.org',
-  '@type': 'Organization',
-  name: 'Abaco Loans Analytics',
-  url: 'https://abaco-loans-analytics.com',
-  description:
-    'Abaco Loans Analytics unifies lending KPIs, governance, and revenue acceleration in one compliant, investor-ready experience.',
-  areaServed: 'Global',
-  brand: {
-    '@type': 'Brand',
-    name: 'Abaco Loans Analytics',
-  },
-  offers: {
-    '@type': 'Offer',
-    category: 'Financial technology',
-    availability: 'https://schema.org/InStock',
-  },
-  hasOfferCatalog: {
-    '@type': 'OfferCatalog',
-    name: 'Growth & Risk Intelligence Suite',
-    itemListElement: products.map((product) => ({
-      '@type': 'Offer',
-      itemOffered: {
-        '@type': 'Service',
-        name: product.title,
-        description: product.detail,
-      },
-    })),
-  },
-  makesOffer: scorecards.map((score) => ({
-    '@type': 'Offer',
-    itemOffered: {
-      '@type': 'Service',
-      name: score.label,
-      description: score.helper,
-    },
-  })),
-}
-
-export default function Home() {
-=======
-const landingPageSchema = z.object({
-  metrics: z.array(
-    z.object({
-      label: z.string().min(1),
-      value: z.string().min(1),
-    })
-  ),
-  products: z.array(
-    z.object({
-      title: z.string().min(1),
-      detail: z.string().min(1),
-    })
-  ),
-  controls: z.array(z.string().min(1)),
-  steps: z.array(
-    z.object({
-      label: z.string().min(1),
-      title: z.string().min(1),
-      copy: z.string().min(1),
-    })
-  ),
-})
-
-const fallbackData: LandingPageData = {
-  metrics: fallbackMetrics,
-  products: fallbackProducts,
-  controls: fallbackControls,
-  steps: fallbackSteps,
-}
-
-function cloneFallback(): LandingPageData {
-  return {
-    metrics: fallbackData.metrics.map((item) => ({ ...item })),
-    products: fallbackData.products.map((item) => ({ ...item })),
-    controls: [...fallbackData.controls],
-    steps: fallbackData.steps.map((item) => ({ ...item })),
-  }
-}
-
-async function getData(): Promise<LandingPageData> {
-  if (!supabase) {
-    return cloneFallback()
+async function fetchLandingPageData(): Promise<LandingPageData> {
+  if (!supabase || !isSupabaseConfigured) {
+    return {
+      metrics: fallbackMetrics,
+      products: fallbackProducts,
+      controls: fallbackControls,
+      steps: fallbackSteps,
+    }
   }
 
-  const { data, error }: PostgrestSingleResponse<LandingPageData> = await supabase
+  const response: PostgrestSingleResponse<LandingPageData> = await supabase
     .from('landing_page_data')
-    .select()
+    .select('*')
     .single()
 
-  if (error || !data) {
-    console.error('Error fetching landing page data:', error)
-    return cloneFallback()
+  if (response.error || !response.data) {
+    return {
+      metrics: fallbackMetrics,
+      products: fallbackProducts,
+      controls: fallbackControls,
+      steps: fallbackSteps,
+    }
   }
 
-  const parsed = landingPageSchema.safeParse(data)
+  const parsed = landingPageDataSchema.safeParse(response.data)
   if (!parsed.success) {
-    console.error('Invalid landing page payload received:', parsed.error.flatten())
-    return cloneFallback()
+    return {
+      metrics: fallbackMetrics,
+      products: fallbackProducts,
+      controls: fallbackControls,
+      steps: fallbackSteps,
+    }
   }
 
->>>>>>> origin/main
   return parsed.data
 }
 
 export default async function Home() {
-  const { metrics, products, controls, steps } = await getData()
->>>>>>> origin/main
+  const landingPageData = await fetchLandingPageData()
 
->>>>>>> origin/main
   return (
-    <main id="main-content" className={styles.page}>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-      />
-      <nav className={styles.nav} aria-label="Primary">
-        <div className={styles.brand}>Abaco Loans</div>
-        <div className={styles.navLinks}>
+    <div className={styles.page}>
+      <nav className={styles.nav}>
+        <div className={styles.logo}>ABACO</div>
+        <ul className={styles.navLinks}>
           {navLinks.map((link) => (
-            <Link key={link.href} href={link.href} className={styles.navLink}>
-              {link.label}
-            </Link>
+            <li key={link.href}>
+              <Link href={link.href}>{link.label}</Link>
+            </li>
           ))}
-        </div>
-        <Link href="#demo" className={styles.navCta}>
-          Book a session
+        </ul>
+        <Link className={styles.primaryCta} href="#demo">
+          Request demo
         </Link>
       </nav>
-      <header className={styles.hero}>
-        <div className={styles.pillRow}>
-          <div className={styles.pill}>Growth & Risk Intelligence</div>
-          <div className={styles.subPill}>Bank-grade controls</div>
-        </div>
-        <h1>Abaco Loans Analytics</h1>
-        <p>
-          A fintech command center that blends underwriting precision, revenue acceleration, and
-          regulatory confidence in one cohesive experience.
-        </p>
-        <div className={styles.actions}>
-          <Link href="#demo" className={styles.primaryButton}>
-            Schedule a demo
-          </Link>
-          <Link href="#products" className={styles.secondaryButton}>
-            Explore products
-          </Link>
-<<<<<<< HEAD
-          <Link href="#kpis" className={styles.linkGhost}>
-            View KPI cockpit
-=======
-          <Link href="/settings" className={styles.secondaryButton}>
-            Open settings
->>>>>>> origin/main
-          </Link>
-        </div>
-        <div className={styles.metrics}>
-          {metrics.map((metric) => (
-            <dl key={metric.label} className={styles.metricCard}>
-              <dt className={styles.metricLabel}>{metric.label}</dt>
-              <dd className={styles.metricValue}>{metric.value}</dd>
-              {metric.helper ? <dd className={styles.metricHelper}>{metric.helper}</dd> : null}
-            </dl>
-          ))}
-        </div>
-      </header>
 
-<<<<<<< HEAD
-      <section id="kpis" aria-labelledby="kpis-heading" className={styles.section}>
-        <div className={styles.sectionHeader}>
-          <p className={styles.eyebrow}>Performance cockpit</p>
-          <h2 id="kpis-heading">Operational KPIs engineered for lenders</h2>
-          <p className={styles.sectionCopy}>
-            Scorecards designed for treasury, risk, operations, and growth teams to make faster,
-            audit-ready calls.
+      <header className={styles.hero} id="main-content">
+        <div className={styles.heroContent}>
+          <p className={styles.eyebrow}>Executive-grade intelligence for lending teams</p>
+          <h1 className={styles.title}>
+            Build governed growth with transparent{' '}
+            <span className={styles.highlight}>credit analytics</span>
+          </h1>
+          <p className={styles.subtitle}>
+            Abaco pairs portfolio intelligence with risk orchestration so finance leaders can scale
+            funding confidently.
           </p>
-        </div>
-        <div className={styles.scoreGrid}>
-          {scorecards.map((item) => (
-            <div key={item.label} className={styles.scoreCard}>
-              <p className={styles.scoreLabel}>{item.label}</p>
-              <p className={styles.scoreValue}>{item.value}</p>
-              <p className={styles.scoreHelper}>{item.helper}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section id="products" aria-labelledby="products-heading" className={styles.section}>
-=======
-      <section id="products" className={styles.section} aria-labelledby="products-heading">
->>>>>>> origin/main
-        <div className={styles.sectionHeader}>
-          <p className={styles.eyebrow}>Customer-centric growth</p>
-          <h2 id="products-heading">Build, fund, and protect every loan strategy</h2>
-          <p className={styles.sectionCopy}>
-            Abaco aligns acquisition, credit, collections, and treasury teams around shared KPIs
-            with zero-friction visibility and auditable execution.
-          </p>
-        </div>
-        <div className={styles.cardGrid}>
-          {products.map((product) => (
-            <div key={product.title} className={styles.card}>
-              <div className={styles.cardHeader}>
-                <h3>{product.title}</h3>
-                {product.kicker ? (
-                  <span className={styles.cardKicker}>{product.kicker}</span>
-                ) : null}
-              </div>
-              <p>{product.detail}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-<<<<<<< HEAD
-      <section id="dashboards" aria-labelledby="dashboards-heading" className={styles.section}>
-        <div className={styles.sectionHeader}>
-          <p className={styles.eyebrow}>Signals and dashboards</p>
-          <h2 id="dashboards-heading">Commercial and financial intelligence on demand</h2>
-          <p className={styles.sectionCopy}>
-            Live dashboards that measure profitability, liquidity, and risk posture with built-in
-            governance for every audience.
-          </p>
-        </div>
-        <div className={styles.dashboardGrid}>
-          {dashboards.map((dashboard) => (
-            <div key={dashboard.title} className={styles.dashboardCard}>
-              <div className={styles.dashboardHeader}>
-                <h3>{dashboard.title}</h3>
-                {dashboard.kicker ? (
-                  <span className={styles.dashboardKicker}>{dashboard.kicker}</span>
-                ) : null}
-              </div>
-              <p>{dashboard.detail}</p>
-            </div>
-          ))}
-        </div>
-        <div className={styles.linkRow}>
-          <Link href="#demo" className={styles.primaryGhost}>
-            Launch a pilot
-          </Link>
-          <Link href="#demo" className={styles.linkGhost}>
-            Download governance pack
-          </Link>
-        </div>
-      </section>
-
-      <section id="compliance" aria-labelledby="compliance-heading" className={styles.section}>
-=======
-      <section className={styles.section} aria-labelledby="excellence-heading">
->>>>>>> origin/main
-        <div className={styles.sectionHeader}>
-          <p className={styles.eyebrow}>Operational excellence</p>
-          <h2 id="compliance-heading">Compliance-first, automation-ready</h2>
-          <p className={styles.sectionCopy}>
-            Deploy with confidence using built-in governance, continuous monitoring, and clear
-            accountabilities for every decision.
-          </p>
-        </div>
-        <div className={styles.compliance}>
-          <ul className={styles.complianceList}>
-            {controls.map((item) => (
-              <li key={item} className={styles.checkItem}>
-                <span className={styles.checkBullet} aria-hidden="true" />
-                <span>{item}</span>
-              </li>
-            ))}
-          </ul>
-          <div className={styles.auditBox}>
-            <p className={styles.auditTitle}>Audit-ready by design</p>
-            <ul>
-              <li>Unified evidence across decisions, payments, and servicing.</li>
-              <li>Exportable traces for regulators, investors, and partners.</li>
-              <li>Service-level alerts with automated escalations.</li>
-            </ul>
-            <Link href="#demo" className={styles.primaryGhost}>
-              Launch a pilot
+          <div className={styles.heroActions}>
+            <Link className={styles.primaryCta} href="#kpis">
+              Explore metrics
+            </Link>
+            <Link className={styles.secondaryCta} href="#dashboards">
+              View dashboards
             </Link>
           </div>
         </div>
-      </section>
+        <div className={styles.heroBadge}>
+          <span className={styles.badgeLabel}>Reliability</span>
+          <strong>99.4% SLA</strong>
+          <p>Guarded by automated playbooks and transparent audit trails.</p>
+        </div>
+      </header>
 
-<<<<<<< HEAD
-      <section id="demo" aria-labelledby="playbook-heading" className={styles.section}>
-=======
-      <section id="demo" className={styles.section} aria-labelledby="playbook-heading">
->>>>>>> origin/main
+      <section className={styles.section} id="kpis">
         <div className={styles.sectionHeader}>
-          <p className={styles.eyebrow}>Delivery playbook</p>
-          <h2 id="playbook-heading">From data to decisions in weeks</h2>
-          <p className={styles.sectionCopy}>
-            Guided onboarding, industrialized documentation, and observability to keep every sprint
-            on budget and on time.
+          <div>
+            <p className={styles.eyebrow}>Portfolio KPIs</p>
+            <h2 className={styles.sectionTitle}>Risk-aware growth signals</h2>
+          </div>
+          <p className={styles.sectionSubhead}>
+            Metrics calibrated for underwriting rigor, investor readiness, and day-to-day operating
+            cadence.
           </p>
         </div>
-        <div className={styles.timeline}>
-          {steps.map((step) => (
-            <div key={step.label} className={styles.timelineStep}>
-              <span className={styles.stepBadge}>{step.label}</span>
-              <div>
-                <h3>{step.title}</h3>
-                <p>{step.copy}</p>
-              </div>
-            </div>
+        <div className={styles.metricsGrid}>
+          {landingPageData.metrics.map((metric) => (
+            <article key={metric.label} className={styles.metricCard}>
+              <p className={styles.metricLabel}>{metric.label}</p>
+              <p className={styles.metricValue}>{metric.value}</p>
+            </article>
           ))}
         </div>
       </section>
-<<<<<<< HEAD
-    </main>
-=======
 
-      <section className={styles.section} id="analytics">
-        <AnalyticsDashboard />
+      <section className={styles.section} id="products">
+        <div className={styles.sectionHeader}>
+          <p className={styles.eyebrow}>Products</p>
+          <h2 className={styles.sectionTitle}>Designed for resilient lending</h2>
+        </div>
+        <div className={styles.productGrid}>
+          {landingPageData.products.map((product) => (
+            <article key={product.title} className={styles.productCard}>
+              <p className={styles.eyebrow}>Capability</p>
+              <h3>{product.title}</h3>
+              <p className={styles.body}>{product.detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.section} id="dashboards">
+        <div className={styles.sectionHeader}>
+          <p className={styles.eyebrow}>Dashboards</p>
+          <h2 className={styles.sectionTitle}>Operational intelligence in one view</h2>
+        </div>
+        <div className={styles.dashboardShell}>
+          <AnalyticsDashboard />
+        </div>
+      </section>
+
+      <section className={styles.section} id="compliance">
+        <div className={styles.sectionHeader}>
+          <p className={styles.eyebrow}>Governance</p>
+          <h2 className={styles.sectionTitle}>Controls that keep auditors confident</h2>
+        </div>
+        <ul className={styles.controlList}>
+          {landingPageData.controls.map((control) => (
+            <li key={control}>{control}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className={styles.section} id="demo">
+        <div className={styles.sectionHeader}>
+          <p className={styles.eyebrow}>Go-live playbook</p>
+          <h2 className={styles.sectionTitle}>Three steps to production</h2>
+        </div>
+        <ol className={styles.stepList}>
+          {landingPageData.steps.map((step) => (
+            <li key={step.label} className={styles.stepCard}>
+              <span className={styles.stepLabel}>{step.label}</span>
+              <div>
+                <h3>{step.title}</h3>
+                <p className={styles.body}>{step.copy}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
       </section>
     </div>
->>>>>>> origin/main
   )
 }

--- a/apps/web/src/components/analytics/ExportControls.tsx
+++ b/apps/web/src/components/analytics/ExportControls.tsx
@@ -58,11 +58,7 @@ export function ExportControls({ analytics }: Props) {
           className={styles.secondaryButton}
           type="button"
           onClick={() =>
-            download(
-              'analytics.md',
-              processedAnalyticsToMarkdown(analytics),
-              'text/markdown'
-            )
+            download('analytics.md', processedAnalyticsToMarkdown(analytics), 'text/markdown')
           }
         >
           Download Markdown

--- a/apps/web/src/lib/loanData.ts
+++ b/apps/web/src/lib/loanData.ts
@@ -26,11 +26,15 @@ export function updateLoanById(
 ): IdentifiedLoanRow[] {
   const targetIndex = rows.findIndex((row) => row.id === updated.id)
   if (targetIndex !== -1) {
-    return rows.map((row, index) => (index === targetIndex ? { ...row, ...updated, id: row.id } : row))
+    return rows.map((row, index) =>
+      index === targetIndex ? { ...row, ...updated, id: row.id } : row
+    )
   }
 
   if (fallbackIndex !== undefined && fallbackIndex >= 0 && fallbackIndex < rows.length) {
-    return rows.map((row, index) => (index === fallbackIndex ? { ...row, ...updated, id: row.id ?? updated.id } : row))
+    return rows.map((row, index) =>
+      index === fallbackIndex ? { ...row, ...updated, id: row.id ?? updated.id } : row
+    )
   }
 
   return rows

--- a/apps/web/src/lib/supabaseClient.ts
+++ b/apps/web/src/lib/supabaseClient.ts
@@ -11,7 +11,6 @@ type Database = {
   }
 }
 
-<<<<<<< HEAD
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim()
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim()
 
@@ -23,10 +22,3 @@ export const supabase: SupabaseClient<Database> | null = hasSupabaseEnv
   : null
 
 export const isSupabaseConfigured = hasSupabaseEnv
-=======
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-
-export const supabase: SupabaseClient<Database> | null =
-  supabaseUrl && supabaseAnonKey ? createClient<Database>(supabaseUrl, supabaseAnonKey) : null
->>>>>>> origin/main

--- a/apps/web/src/types/landingPage.ts
+++ b/apps/web/src/types/landingPage.ts
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import { z } from 'zod'
 
 const metricSchema = z.object({
@@ -32,27 +31,3 @@ export type LandingPageData = z.infer<typeof landingPageDataSchema>
 export const EMPTY_LANDING_PAGE_DATA: LandingPageData = Object.freeze(
   landingPageDataSchema.parse({})
 )
-=======
-export interface Metric {
-  value: string
-  label: string
-}
-
-export interface Product {
-  title: string
-  detail: string
-}
-
-export interface Step {
-  label: string
-  title: string
-  copy: string
-}
-
-export interface LandingPageData {
-  metrics: Metric[]
-  products: Product[]
-  controls: string[]
-  steps: Step[]
-}
->>>>>>> origin/main

--- a/docs/Abaco_2026_North_Star_Metric_Strategy.md
+++ b/docs/Abaco_2026_North_Star_Metric_Strategy.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # 🧭 Abaco 2026 — North Star Metric Strategy (NSM)
 
 ## 1. Executive summary
@@ -94,7 +93,6 @@ This measures the total processed volume from clients who repeat, reflecting ret
 2. Activate alerts for concentration and rotation/replines drops vs plan.
 3. Link funnels by channel (Digital ≤$10k, Mixed $10–50k, KAM $50–150k) to the NSM to optimize CAC and churn.
 4. Report the NSM and supporting KPIs in the weekly/monthly/QBR cadence.
-=======
 # 🧭 Abaco 2026 — Estrategia de la Métrica Estrella del Norte (NSM)
 
 ## 1. Resumen ejecutivo
@@ -191,4 +189,3 @@ Esta métrica mide el volumen total procesado por clientes que repiten, reflejan
 3. Vincular embudos por canal (Digital ≤$10k, Mixto $10–50k, KAM $50–150k) al NSM para optimizar CAC y churn.
 4. Reportar NSM y KPIs de apoyo en la cadencia semanal/mensual/QBR.
 
->>>>>>> origin/main

--- a/docs/MCP_CONFIGURATION.md
+++ b/docs/MCP_CONFIGURATION.md
@@ -24,11 +24,7 @@ After launching Codex and opening the TUI, run `/mcp` to see your actively conne
 
 ## Config file (`config.toml`)
 
-<<<<<<< HEAD
-For granular control, edit `~/.codex/config.toml`. In the IDE extension, open the gear icon in the top right, choose **MCP settings**, then **Open config.toml**.
-=======
 For granular control, edit `~/.codex/config.toml` (on Windows, `%USERPROFILE%\\.codex\\config.toml`). In the IDE extension, open the gear icon in the top right, choose **MCP settings**, then **Open config.toml** to modify the active config file.
->>>>>>> origin/main
 
 Each MCP server uses its own `[mcp_servers.<server-name>]` table.
 
@@ -50,11 +46,7 @@ Each MCP server uses its own `[mcp_servers.<server-name>]` table.
 - `tool_timeout_sec` (optional): timeout in seconds for tools to run (default 60).
 - `enabled` (optional): set `false` to disable a configured server without deleting it.
 - `enabled_tools` (optional): allow-list of tools exposed from the server.
-<<<<<<< HEAD
-- `disabled_tools` (optional): deny-list of tools to hide (applied after `enabled_tools`).
-=======
 - `disabled_tools` (optional): deny-list of tools to hide; it overrides overlaps with `enabled_tools`.
->>>>>>> origin/main
 - `[features].rmcp_client` (optional): enables the Rust MCP client for STDIO servers and OAuth on streamable HTTP.
 - `experimental_use_rmcp_client` (optional): older flag for OAuth/streamable HTTP; prefer `[features].rmcp_client`.
 - Set feature flags inside the top-level `[features]` table (not under a specific server).
@@ -84,11 +76,7 @@ http_headers = { "X-Figma-Region" = "us-east-1" }
 [mcp_servers.chrome_devtools]
 url = "http://localhost:3000/mcp"
 enabled_tools = ["open", "screenshot"]
-<<<<<<< HEAD
-disabled_tools = ["screenshot"] # applied after enabled_tools
-=======
 disabled_tools = ["open"] # disabled takes precedence even if also listed in enabled_tools
->>>>>>> origin/main
 startup_timeout_sec = 20
 tool_timeout_sec = 45
 enabled = true

--- a/exports/presentation/ABACO_CEO_EXEC_PRESENTATION.md
+++ b/exports/presentation/ABACO_CEO_EXEC_PRESENTATION.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # 🚀 ABACO FINTECH — CEO OPERATING SYSTEM v2
 ### Board Presentation — Oct-16, 2025 (Mid-month snapshot)
 
@@ -86,7 +85,6 @@
 - "Default 0% today, policy ≤4%, target <1.5%; data quality 78% → >95% by Nov-25; concentration under control."
 - "EBITDA path: -$10K/month today → +$100-150K/month by Q4-26; cash-positive by Q2-26; Series B optionality preserved."
 - **Success by Dec-31-26:** AUM $16.4MM ✓; 500 active customers ✓; EBITDA +$1.2-1.5MM annually ✓; LTV:CAC >4:1 blended ✓; 60% new from embedded ✓; data quality >95% ✓; default <1.5% ✓; Series B closed with upside ✓.
-=======
 # ABACO CEO Exec Presentation
 
 - **Market TAM (total addressable market) validation (El Salvador, private-sector factoring):** 47,788 formal MSMEs (micro, small, and medium enterprises; BCR 2024 dataset: 34,710 micro, 9,881 small, 3,197 medium). Applying average revenues ($60K / $600K / $3.5M) and a 15% receivables factor yields ~$2.880B of outstanding invoices; subtracting ~$0.141B B2G (business-to-government) exposure (12% PAC 2023 × MIPYME quota) leaves ~$2.739B TAM net. With ~60-day rotation (~6x annually) and 75% eligibility, annualized TAM is ~$12.470B of financeable private-sector invoices.
@@ -106,4 +104,3 @@
 - **STP:** straight-through processing
 - **T2F:** time to funding
 - **TAM:** total addressable market
->>>>>>> origin/main

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,9 +6,8 @@ sonar.projectVersion=1.0
 
 sonar.sourceEncoding=UTF-8
 
-<<<<<<< HEAD
-# Focus analysis on core application code to reduce noise from tooling assets
-sonar.sources=apps/web/src,src
+# Source directories (adjust if structure changes)
+sonar.sources=apps,src,packages
 
 # Exclude artifacts, dependencies, and generated outputs from source analysis
 sonar.exclusions=\
@@ -40,19 +39,6 @@ sonar.test.inclusions=tests/**/*.py,\
 
 # Keep TypeScript analysis aligned with the Next.js project configuration
 sonar.typescript.tsconfigPath=apps/web/tsconfig.json
-=======
-# Source directories (adjust if your structure changes). `packages` is kept
-# tracked (see packages/README.md) so shared libraries can be analyzed when
-# added.
-sonar.sources=apps,packages
-
-# Exclude artifacts, dependencies, and test files from source analysis
-sonar.exclusions=**/node_modules/**,**/.next/**,**/dist/**,**/.turbo/**,**/artifacts/**,**/.github/**,**/*.md,data_samples/**,coverage/**,**/.gradle/**,**/build/**
-
-sonar.typescript.tsconfigPath=apps/web/tsconfig.json
-sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
-sonar.javascript.lcov.reportPaths=apps/web/coverage/lcov.info
 sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
 sonar.javascript.lcov.reportPaths=apps/web/coverage/lcov.info
 sonar.python.coverage.reportPaths=coverage-python.xml
->>>>>>> origin/main

--- a/src/analytics_metrics.py
+++ b/src/analytics_metrics.py
@@ -1,32 +1,18 @@
-<<<<<<< HEAD
 from __future__ import annotations
 
-from typing import Dict, Iterable, Tuple
-
 import numpy as np
 import pandas as pd
 
-
-=======
-import numpy as np
-import pandas as pd
-
->>>>>>> upstream/main
 CURRENCY_SYMBOLS = r"[₡$€£¥₽%]"
 
 
 def standardize_numeric(series: pd.Series) -> pd.Series:
-<<<<<<< HEAD
-    cleaned = (
-        series.astype(str).str.strip()
-=======
     if pd.api.types.is_numeric_dtype(series):
         return series
 
     cleaned = (
         series.astype(str)
         .str.strip()
->>>>>>> upstream/main
         .str.replace(CURRENCY_SYMBOLS, "", regex=True)
         .str.replace(",", "", regex=False)
         .replace({"": np.nan, "nan": np.nan})
@@ -34,86 +20,6 @@ def standardize_numeric(series: pd.Series) -> pd.Series:
     return pd.to_numeric(cleaned, errors="coerce")
 
 
-<<<<<<< HEAD
-def calculate_quality_score(df: pd.DataFrame) -> int:
-    if df.empty:
-        return 0
-    penalty = df.isna().mean().sum() * 10
-    score = max(0, min(100, 100 - penalty))
-    return int(round(score))
-
-
-def _assert_required_columns(df: pd.DataFrame, required: Iterable[str]) -> None:
-    if missing := set(required) - set(df.columns):
-        raise ValueError(f"Missing required columns: {', '.join(sorted(missing))}")
-
-
-def portfolio_kpis(df: pd.DataFrame) -> Tuple[Dict[str, float], pd.DataFrame]:
-    required = {
-        "loan_amount",
-        "appraised_value",
-        "borrower_income",
-        "monthly_debt",
-        "loan_status",
-        "principal_balance",
-        "interest_rate",
-    }
-    _assert_required_columns(df, required)
-
-    work = df.copy()
-    work["ltv_ratio"] = np.where(
-        work["appraised_value"] > 0,
-        (work["loan_amount"] / work["appraised_value"]) * 100,
-        np.nan,
-    )
-    monthly_income = work["borrower_income"] / 12
-    work["dti_ratio"] = np.where(
-        monthly_income > 0,
-        (work["monthly_debt"] / monthly_income) * 100,
-        np.nan,
-    )
-
-    delinquent_statuses = {"30-59 days past due", "60-89 days past due", "90+ days past due"}
-    total_loans = len(work)
-    delinquent_count = work["loan_status"].isin(delinquent_statuses).sum()
-    delinquency_rate = (delinquent_count / total_loans) * 100 if total_loans else 0.0
-
-    total_principal = work["principal_balance"].sum()
-    weighted_interest = (work["interest_rate"] * work["principal_balance"]).sum()
-    portfolio_yield = (weighted_interest / total_principal) * 100 if total_principal else 0.0
-
-    metrics = {
-        "delinquency_rate": delinquency_rate,
-        "portfolio_yield": portfolio_yield,
-        "average_ltv": 0.0
-        if work.empty
-        else float(np.nan_to_num(work["ltv_ratio"].mean(), nan=0.0)),
-        "average_dti": 0.0
-        if work.empty
-        else float(np.nan_to_num(work["dti_ratio"].mean(), nan=0.0)),
-    }
-    return metrics, work
-
-
-def project_growth(
-    current_yield: float,
-    target_yield: float,
-    current_loans: float,
-    target_loans: float,
-    periods: int = 6,
-) -> pd.DataFrame:
-    if periods < 2:
-        raise ValueError("periods must be at least 2 to create a projection range")
-    months = pd.date_range(start=pd.Timestamp.now().normalize(), periods=periods, freq="MS")
-    projection = pd.DataFrame(
-        {
-            "month": months,
-            "yield": np.linspace(current_yield, target_yield, periods),
-            "loan_volume": np.linspace(current_loans, target_loans, periods),
-        }
-    )
-    return projection.assign(month=lambda d: d["month"].dt.strftime("%b %Y"))
-=======
 def project_growth(
     current_yield: float,
     target_yield: float,
@@ -193,4 +99,3 @@ def portfolio_kpis(df: pd.DataFrame) -> tuple[dict[str, float], pd.DataFrame]:
         "average_dti": average_dti,
     }
     return metrics, enriched
->>>>>>> upstream/main

--- a/streamlit_app/__init__.py
+++ b/streamlit_app/__init__.py
@@ -1,15 +1,3 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-"""Streamlit app package initialization."""
-
-from .utils import FeatureEngineer
-
-__all__ = ["FeatureEngineer"]
-=======
 """Package initializer for Streamlit app utilities and shared modules."""
 
 __all__ = ["utils"]
->>>>>>> upstream/main
-=======
-"""Streamlit application package for loan analytics utilities and UI."""
->>>>>>> origin/main

--- a/streamlit_app/utils/__init__.py
+++ b/streamlit_app/utils/__init__.py
@@ -1,11 +1,3 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-"""Utility package for feature engineering helpers."""
-
-from .feature_engineering import FeatureEngineer
-
-__all__ = ["FeatureEngineer"]
-=======
 """Public utilities exposed by :mod:`streamlit_app.utils` with lazy loading."""
 
 from importlib import import_module
@@ -56,7 +48,3 @@ def __dir__() -> List[str]:
     """Surface lazily exported attributes to introspection utilities."""
 
     return sorted(set(__all__) | set(globals().keys()))
->>>>>>> upstream/main
-=======
-"""Utility package for feature engineering and helpers used by the Streamlit app."""
->>>>>>> origin/main

--- a/tests/test_analytics_metrics.py
+++ b/tests/test_analytics_metrics.py
@@ -1,21 +1,3 @@
-<<<<<<< HEAD
-import pandas as pd
-import pytest
-
-from src.analytics_metrics import calculate_quality_score, portfolio_kpis, project_growth, standardize_numeric
-
-
-def sample_df():
-    return pd.DataFrame(
-        {
-            "loan_amount": [100000, 200000, 150000],
-            "appraised_value": [125000, 210000, 180000],
-            "borrower_income": [60000, 80000, 75000],
-            "monthly_debt": [1200, 1800, 1500],
-            "loan_status": ["current", "30-59 days past due", "current"],
-            "principal_balance": [90000, 195000, 140000],
-            "interest_rate": [0.05, 0.06, 0.055],
-=======
 import numpy as np
 import pandas as pd
 import pytest
@@ -39,7 +21,6 @@ def sample_df() -> pd.DataFrame:
             "principal_balance": [10000, 5000, 15000],
             "interest_rate": [0.05, 0.07, 0.06],
             "loan_status": ["current", "delinquent", "current"],
->>>>>>> upstream/main
         }
     )
 
@@ -74,105 +55,24 @@ def test_standardize_numeric_handles_symbols():
     assert cleaned.iloc[10] == 7500.0
 
 
-<<<<<<< HEAD
-def test_calculate_quality_score_rewards_complete_data():
-    df = sample_df()
-    score = calculate_quality_score(df)
-    assert isinstance(score, int)
-    assert score == 100
-
-    df_with_missing = df.copy()
-    df_with_missing.loc[0, "loan_amount"] = None
-    penalized_score = calculate_quality_score(df_with_missing)
-    assert isinstance(penalized_score, int)
-    assert penalized_score < 100
-
-
-def test_calculate_quality_score_empty_dataframe_returns_zero():
-    empty_df = pd.DataFrame(columns=sample_df().columns)
-    score = calculate_quality_score(empty_df)
-    assert isinstance(score, int)
-    assert score == 0
-
-
-def test_calculate_quality_score_is_clamped_at_zero():
-    df = sample_df().copy()
-    for col in df.columns:
-        df[col] = None
-    for i in range(5):
-        df[f"extra_{i}"] = None
-
-    score = calculate_quality_score(df)
-    assert isinstance(score, int)
-    assert score == 0
-
-
-def test_portfolio_kpis_returns_expected_metrics():
-    metrics, enriched = portfolio_kpis(sample_df())
-    assert set(metrics.keys()) == {"delinquency_rate", "portfolio_yield", "average_ltv", "average_dti"}
-    assert "ltv_ratio" in enriched.columns
-    assert "dti_ratio" in enriched.columns
-
-
-def test_portfolio_kpis_missing_column_raises():
-    df = sample_df().drop(columns=["loan_amount"])
-    with pytest.raises(ValueError, match="Missing required columns: loan_amount"):
-        portfolio_kpis(df)
-
-
-def test_portfolio_kpis_handles_empty_frame():
-    df = sample_df().iloc[:0]
-    metrics, enriched = portfolio_kpis(df)
-    assert metrics == {
-        "delinquency_rate": 0.0,
-        "portfolio_yield": 0.0,
-        "average_ltv": 0.0,
-        "average_dti": 0.0,
-    }
-    assert enriched.empty
-
-
-def test_portfolio_kpis_zero_principal_yield_is_zero():
-    df = sample_df()
-    df["principal_balance"] = 0
-    metrics, _ = portfolio_kpis(df)
-    assert metrics["portfolio_yield"] == 0.0
-
-
-def test_portfolio_kpis_dti_nan_when_income_non_positive():
-    df = sample_df()
-    df["borrower_income"] = [0, -5000, 0]
-    metrics, enriched = portfolio_kpis(df)
-    assert enriched["dti_ratio"].isna().all()
-    assert metrics["average_dti"] == 0.0
-
-
-def test_portfolio_kpis_ltv_nan_when_appraisal_non_positive():
-    df = sample_df()
-    df["appraised_value"] = [0, -100000, 0]
-    metrics, enriched = portfolio_kpis(df)
-    assert enriched["ltv_ratio"].isna().all()
-    assert metrics["average_ltv"] == 0.0
-
-=======
 def test_standardize_numeric_passes_through_numeric_series():
     series = pd.Series([1, 2.5, -3])
     cleaned = standardize_numeric(series)
-    assert cleaned.tolist() == [1.0, 2.5, -3.0]
-    assert cleaned.dtype == series.dtype
+    assert cleaned.tolist() == [1, 2.5, -3]
+    assert np.issubdtype(cleaned.dtype, np.number)
 
 
 def test_standardize_numeric_handles_negative_symbols_and_commas():
-    series = pd.Series([
-        "-1,200",
-        "-$3,000",
-        "-25%",
-    ])
+    series = pd.Series(["-1,200", "-$3,000", "-25%"])
     cleaned = standardize_numeric(series)
     assert cleaned.iloc[0] == -1200.0
     assert cleaned.iloc[1] == -3000.0
     assert cleaned.iloc[2] == -25.0
->>>>>>> upstream/main
+
+
+def test_project_growth_requires_minimum_periods():
+    with pytest.raises(ValueError, match="periods must be at least 2"):
+        project_growth(1.0, 2.0, 100, 200, periods=1)
 
 
 def test_project_growth_builds_monotonic_path():
@@ -182,31 +82,12 @@ def test_project_growth_builds_monotonic_path():
     assert projection["yield"].iloc[-1] == 2.0
     assert projection["loan_volume"].iloc[0] == 100
     assert projection["loan_volume"].iloc[-1] == 200
+    assert pd.api.types.is_datetime64_any_dtype(projection["date"])
 
 
-<<<<<<< HEAD
-def test_project_growth_rejects_insufficient_periods():
-    with pytest.raises(ValueError, match="periods must be at least 2"):
-        project_growth(1.0, 2.0, 100, 200, periods=1)
-
-
-def test_project_growth_formats_month_labels():
-    projection = project_growth(1.0, 1.5, 100, 120, periods=3)
-    assert projection["month"].str.match(r"^[A-Z][a-z]{2} \d{4}$").all()
-
-
-def test_project_growth_supports_decreasing_targets():
-    projection = project_growth(2.0, 1.0, 200, 100, periods=3)
-    assert projection["yield"].is_monotonic_decreasing
-    assert projection["loan_volume"].is_monotonic_decreasing
-=======
 def test_project_growth_uses_default_periods():
     projection = project_growth(1.0, 2.0, 100, 200)
     assert len(projection) == 6
-    assert projection["yield"].iloc[0] == 1.0
-    assert projection["yield"].iloc[-1] == 2.0
-    assert projection["loan_volume"].iloc[0] == 100
-    assert projection["loan_volume"].iloc[-1] == 200
 
 
 def test_calculate_quality_score_handles_empty_df():
@@ -221,7 +102,7 @@ def test_calculate_quality_score_counts_completeness():
     assert score == 75
 
 
-def test_portfolio_kpis_returns_expected_metrics(sample_df):
+def test_portfolio_kpis_returns_expected_metrics(sample_df: pd.DataFrame):
     df = sample_df
     metrics, enriched = portfolio_kpis(df)
     assert set(metrics.keys()) == {"delinquency_rate", "portfolio_yield", "average_ltv", "average_dti"}
@@ -234,9 +115,7 @@ def test_portfolio_kpis_returns_expected_metrics(sample_df):
     )
     expected_portfolio_yield = (df["principal_balance"] * df["interest_rate"]).sum() / df["principal_balance"].sum()
     expected_average_ltv = (df["loan_amount"] / df["appraised_value"]).mean()
-    expected_average_dti = (
-        df["monthly_debt"] / (df["borrower_income"] / 12)
-    ).mean()
+    expected_average_dti = (df["monthly_debt"] / (df["borrower_income"] / 12)).mean()
 
     assert metrics["delinquency_rate"] == pytest.approx(expected_delinquency_rate, rel=1e-6, abs=1e-9)
     assert metrics["portfolio_yield"] == pytest.approx(expected_portfolio_yield, rel=1e-6, abs=1e-9)
@@ -244,37 +123,13 @@ def test_portfolio_kpis_returns_expected_metrics(sample_df):
     assert metrics["average_dti"] == pytest.approx(expected_average_dti, rel=1e-6, abs=1e-9)
 
 
-def test_portfolio_kpis_zero_principal_yield_is_zero(sample_df):
-    df = sample_df.copy()
-    df["principal_balance"] = 0
-    metrics, _ = portfolio_kpis(df)
-    assert metrics["portfolio_yield"] == 0.0
+def test_portfolio_kpis_missing_column_raises(sample_df: pd.DataFrame):
+    df = sample_df.drop(columns=["loan_amount"])
+    with pytest.raises(ValueError, match="Missing required columns: loan_amount"):
+        portfolio_kpis(df)
 
 
-def test_portfolio_kpis_dti_nan_when_income_non_positive(sample_df):
-    df = sample_df.copy()
-    df["borrower_income"] = [0, -5000, 0]
-    metrics, enriched = portfolio_kpis(df)
-    assert enriched["dti_ratio"].isna().all()
-    assert metrics["average_dti"] == 0.0
-
-
-def test_portfolio_kpis_dti_mixed_income_ignores_nan_in_average(sample_df):
-    df = sample_df.copy()
-    df["borrower_income"] = [60000, 0, -5000]
-    metrics, enriched = portfolio_kpis(df)
-    non_positive_mask = df["borrower_income"] <= 0
-    positive_mask = df["borrower_income"] > 0
-    assert enriched.loc[non_positive_mask, "dti_ratio"].isna().all()
-    assert enriched.loc[positive_mask, "dti_ratio"].notna().all()
-    expected_dti = (
-        df.loc[positive_mask, "monthly_debt"] /
-        (df.loc[positive_mask, "borrower_income"] / 12)
-    ).mean()
-    assert metrics["average_dti"] == pytest.approx(expected_dti)
-
-
-def test_portfolio_kpis_handles_empty_frame(sample_df):
+def test_portfolio_kpis_handles_empty_frame(sample_df: pd.DataFrame):
     df = sample_df.iloc[:0]
     metrics, enriched = portfolio_kpis(df)
     assert metrics == {
@@ -284,4 +139,18 @@ def test_portfolio_kpis_handles_empty_frame(sample_df):
         "average_dti": 0.0,
     }
     assert enriched.empty
->>>>>>> upstream/main
+
+
+def test_portfolio_kpis_zero_principal_yield_is_zero(sample_df: pd.DataFrame):
+    df = sample_df.copy()
+    df["principal_balance"] = 0
+    metrics, _ = portfolio_kpis(df)
+    assert metrics["portfolio_yield"] == 0.0
+
+
+def test_portfolio_kpis_dti_nan_when_income_non_positive(sample_df: pd.DataFrame):
+    df = sample_df.copy()
+    df["borrower_income"] = [0, -5000, 0]
+    metrics, enriched = portfolio_kpis(df)
+    assert enriched["dti_ratio"].isna().all()
+    assert metrics["average_dti"] == 0.0

--- a/tests/test_azure_blob_exporter.py
+++ b/tests/test_azure_blob_exporter.py
@@ -12,9 +12,7 @@ def test_upload_metrics_uses_blob_service_client():
     blob_service_client = Mock()
     blob_service_client.get_container_client.return_value = container_client
 
-    exporter = AzureBlobKPIExporter(
-        container_name="kpis", blob_service_client=blob_service_client
-    )
+    exporter = AzureBlobKPIExporter(container_name="kpis", blob_service_client=blob_service_client)
     blob_path = exporter.upload_metrics({"portfolio_yield_percent": 4.2})
 
     blob_service_client.get_container_client.assert_called_once_with("kpis")
@@ -29,32 +27,23 @@ def test_upload_metrics_uses_blob_service_client():
 
 
 def test_upload_metrics_requires_payload():
-    exporter = AzureBlobKPIExporter(
-        container_name="kpis", blob_service_client=Mock()
-    )
+    exporter = AzureBlobKPIExporter(container_name="kpis", blob_service_client=Mock())
     with pytest.raises(ValueError):
         exporter.upload_metrics({})
 
 
 def test_upload_metrics_rejects_non_numeric_payloads():
-    exporter = AzureBlobKPIExporter(
-        container_name="kpis", blob_service_client=Mock()
-    )
+    exporter = AzureBlobKPIExporter(container_name="kpis", blob_service_client=Mock())
     with pytest.raises(ValueError):
         exporter.upload_metrics({"portfolio": "high"})
 
 
-<<<<<<< HEAD
 def test_upload_metrics_rejects_non_string_blob_name():
-    exporter = AzureBlobKPIExporter(
-        container_name="kpis", blob_service_client=Mock()
-    )
+    exporter = AzureBlobKPIExporter(container_name="kpis", blob_service_client=Mock())
     with pytest.raises(ValueError):
         exporter.upload_metrics({"portfolio_yield_percent": 4.2}, blob_name=42)  # type: ignore[arg-type]
 
 
-=======
->>>>>>> origin/main
 def test_exporter_requires_valid_container_name():
     with pytest.raises(ValueError):
         AzureBlobKPIExporter(container_name="  ", blob_service_client=Mock())
@@ -72,9 +61,7 @@ def test_engine_exports_to_blob(monkeypatch):
     }
     engine = LoanAnalyticsEngine.from_dict(data)
 
-    exporter = AzureBlobKPIExporter(
-        container_name="kpis", blob_service_client=Mock()
-    )
+    exporter = AzureBlobKPIExporter(container_name="kpis", blob_service_client=Mock())
     upload_spy = Mock(return_value="kpis/kpi-dashboard.json")
     exporter.upload_metrics = upload_spy
 
@@ -85,7 +72,6 @@ def test_engine_exports_to_blob(monkeypatch):
     assert called_blob_name == "dashboard.json"
     assert "portfolio_delinquency_rate_percent" in called_payload
     assert result_path == "kpis/kpi-dashboard.json"
-<<<<<<< HEAD
 
 
 def test_engine_rejects_non_string_blob_name():
@@ -100,11 +86,7 @@ def test_engine_rejects_non_string_blob_name():
     }
     engine = LoanAnalyticsEngine.from_dict(data)
 
-    exporter = AzureBlobKPIExporter(
-        container_name="kpis", blob_service_client=Mock()
-    )
+    exporter = AzureBlobKPIExporter(container_name="kpis", blob_service_client=Mock())
 
     with pytest.raises(ValueError):
         engine.export_kpis_to_blob(exporter, blob_name=123)  # type: ignore[arg-type]
-=======
->>>>>>> origin/main

--- a/tests/test_enterprise_analytics_engine.py
+++ b/tests/test_enterprise_analytics_engine.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import math
 import sys
 from pathlib import Path
@@ -34,9 +33,7 @@ def test_portfolio_interest_and_risk_tracks_defaults():
     near_prime = LoanPosition(principal=75_000, annual_interest_rate=0.14, term_months=36, default_probability=0.05)
     subprime = LoanPosition(principal=40_000, annual_interest_rate=0.2, term_months=18, default_probability=0.12)
 
-    monthly_interest, portfolio_loss = portfolio_interest_and_risk(
-        loans=[prime, near_prime, subprime], loss_given_default=0.45
-    )
+    monthly_interest, portfolio_loss = portfolio_interest_and_risk(loans=[prime, near_prime, subprime], loss_given_default=0.45)
 
     expected_interest = (
         prime.principal * (prime.annual_interest_rate / 12)
@@ -105,138 +102,3 @@ def test_portfolio_kpis_surfaces_weighted_metrics():
     assert kpis.risk_adjusted_return == pytest.approx(
         (expected_interest - expected_loss_value) / expected_exposure
     )
-=======
-from pathlib import Path
-import sys
-
-import pandas as pd
-import pytest
-
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from src.enterprise_analytics_engine import LoanAnalyticsEngine, LoanAnalyticsConfig
-
-
-def sample_frame():
-    return pd.DataFrame(
-        {
-            "loan_id": ["L1", "L2", "L3", "L4"],
-            "principal": [100000, 50000, 75000, 60000],
-            "interest_rate": [0.12, 0.08, 0.10, 0.09],
-            "term_months": [24, 18, 24, 12],
-            "origination_date": [
-                "2023-01-15",
-                "2023-02-10",
-                "2022-12-05",
-                "2023-04-20",
-            ],
-            "status": ["current", "30dpd", "defaulted", "current"],
-            "outstanding_principal": [80000, 30000, 0, 40000],
-            "days_in_arrears": [0, 35, 120, 0],
-            "charge_off_amount": [0, 0, 50000, 0],
-            "recoveries": [0, 0, 10000, 0],
-            "paid_principal": [12000, 8000, 5000, 10000],
-            "region": ["LATAM", "LATAM", "EMEA", "LATAM"],
-            "product": ["SME", "SME", "Corporate", "SME"],
-        }
-    )
-
-
-def test_portfolio_kpis_compute_expected_values():
-    engine = LoanAnalyticsEngine(sample_frame(), config=LoanAnalyticsConfig(currency="EUR"))
-    kpis = engine.portfolio_kpis()
-
-    assert kpis["currency"] == "EUR"
-    assert pytest.approx(kpis["total_outstanding"], rel=1e-6) == 150000
-    assert pytest.approx(kpis["total_principal"], rel=1e-6) == 285000
-    assert pytest.approx(kpis["weighted_interest_rate"], rel=1e-6) == 0.104
-    assert pytest.approx(kpis["non_performing_loan_ratio"], rel=1e-6) == 0
-    assert pytest.approx(kpis["default_rate"], rel=1e-6) == 0.25
-    assert pytest.approx(kpis["loss_given_default"], rel=1e-6) == 0.8
-    assert pytest.approx(kpis["prepayment_rate"], rel=1e-6) == pytest.approx(35000 / 285000)
-    assert kpis["repayment_velocity"] > 1
-
-
-def test_prepare_data_validates_inputs():
-    base = sample_frame()
-    missing_cols = base.drop(columns=["interest_rate"])
-
-    with pytest.raises(ValueError):
-        LoanAnalyticsEngine(missing_cols)
-
-    invalid_date = base.copy()
-    invalid_date.loc[0, "origination_date"] = "not-a-date"
-    with pytest.raises(ValueError):
-        LoanAnalyticsEngine(invalid_date)
-
-
-def test_prepare_data_rejects_non_numeric_values():
-    base = sample_frame()
-    base["principal"] = base["principal"].astype(object)
-    base.loc[0, "principal"] = "one hundred"
-
-    with pytest.raises(ValueError):
-        LoanAnalyticsEngine(base)
-
-
-def test_prepare_data_rejects_missing_numeric_values_by_default():
-    base = sample_frame()
-    base.loc[2, "outstanding_principal"] = None
-
-    with pytest.raises(ValueError):
-        LoanAnalyticsEngine(base)
-
-
-def test_prepare_data_allows_explicit_numeric_fill_value():
-    base = sample_frame()
-    base.loc[2, "recoveries"] = None
-
-    engine = LoanAnalyticsEngine(
-        base, config=LoanAnalyticsConfig(numeric_missing_fill_value=0.0)
-    )
-
-    assert engine.data.loc[2, "recoveries"] == 0
-
-
-def test_prepare_data_handles_missing_status_with_arrears_flag():
-    base = sample_frame()
-    base.loc[1, "status"] = None
-    base.loc[1, "days_in_arrears"] = 200
-
-    engine = LoanAnalyticsEngine(base)
-    assert bool(engine.data.loc[1, "arrears_flag"]) is True
-
-
-def test_segment_kpis_respects_groupings():
-    engine = LoanAnalyticsEngine(sample_frame())
-    segmented = engine.segment_kpis(["region"])
-
-    latam_row = segmented.loc[segmented["region"] == "LATAM"].iloc[0]
-    emea_row = segmented.loc[segmented["region"] == "EMEA"].iloc[0]
-
-    assert pytest.approx(latam_row["total_outstanding"], rel=1e-6) == 150000
-    assert pytest.approx(latam_row["default_rate"], rel=1e-6) == 0
-    assert pytest.approx(emea_row["loss_given_default"], rel=1e-6) == 0.8
-    assert pytest.approx(emea_row["total_principal"], rel=1e-6) == 75000
-
-
-def test_vintage_default_table_orders_by_quarter():
-    engine = LoanAnalyticsEngine(sample_frame())
-    vintages = engine.vintage_default_table()
-
-    assert list(vintages["origination_quarter"]) == [pd.Period("2022Q4"), pd.Period("2023Q1"), pd.Period("2023Q2")]
-    assert vintages.loc[vintages["origination_quarter"] == pd.Period("2022Q4"), "default_rate"].iloc[0] == 1
-    assert vintages.loc[vintages["origination_quarter"] == pd.Period("2023Q1"), "default_rate"].iloc[0] == 0
-
-
-def test_cashflow_curve_generates_cumulative_view():
-    engine = LoanAnalyticsEngine(sample_frame())
-    curve = engine.cashflow_curve(freq="Q")
-
-    assert "cumulative_cashflow" in curve.columns
-    assert len(curve) == 3
-    expected_cumulative = [-70000, -200000, -250000]
-    assert curve["cumulative_cashflow"].tolist() == expected_cumulative
->>>>>>> origin/main


### PR DESCRIPTION
## Summary
- normalize analytics metric utilities and regenerate Streamlit ingestion/visualization flow after resolving merge artifacts
- refresh Next.js landing page content with Supabase-backed fallback data and regenerated package lock
- tighten Azure blob exporter validations, documentation clean-up, and updated test coverage for analytics pipelines

## Testing
- npm run lint
- PYTHONPATH=. pytest tests/test_analytics_metrics.py tests/test_azure_blob_exporter.py tests/test_enterprise_analytics_engine.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693131c81a8483338693f0ba225aa917)

## Summary by Sourcery

Resolve merge artifacts across the web, analytics, and documentation codebases while refreshing landing page content and tightening analytics utilities and exporters.

New Features:
- Add Supabase-backed landing page data retrieval with schema validation and typed fallbacks for metrics, products, controls, and steps.
- Embed the analytics dashboard directly on the web landing page dashboards section and wire it to new KPI sections.

Bug Fixes:
- Fix Streamlit ingestion idempotency and file parsing by normalizing upload signatures, safely re-reading files, and handling CSV parse failures.
- Correct analytics growth projection outputs and naming so downstream visualizations receive consistent month labels and loan volume fields.
- Harden Azure Blob KPI export validation by enforcing non-empty numeric metric payloads and stricter blob name type checks.
- Restore Supabase client initialization to respect trimmed environment variables and proper configuration checks.

Enhancements:
- Refresh the marketing landing page structure, copy, and navigation to center around KPIs, dashboards, governance, and go-live steps using Supabase-backed content.
- Normalize analytics text and payer column detection utilities to improve payer coverage scans and quality audits.
- Unify analytics metric helpers in Python, including safer numeric cleaning and growth projection behaviors, and clean up duplicated implementations after merges.
- Simplify and harden the Streamlit app’s ingestion flow, upload signature computation, and UI theming for more reliable analytics runs.
- Tighten typings and immutability for landing page data definitions and shared web data modules.
- Refine enterprise analytics engine typing and protocol definitions to support pluggable KPI exporters.

Build:
- Align SonarQube configuration with the current monorepo layout by updating source roots, exclusions, and coverage report paths.

Documentation:
- Reconcile duplicated documentation sections for MCP configuration, North Star metric strategy, and executive presentation exports, clarifying feature flags and examples.
- Update README to reference integrations documentation and clean up merge remnants.

Tests:
- Consolidate and expand analytics metric tests around numeric standardization, growth projections, and portfolio KPIs, including edge cases for empty frames and invalid inputs.
- Extend Azure blob exporter tests to cover invalid container and blob names and engine export wiring.
- Clean up enterprise analytics engine tests after merges to focus on portfolio risk and KPI behavior.