### PR TITLE
chore: codex workflow smoke test

### DIFF
--- a/docs/codex-workflow-smoketest.md
+++ b/docs/codex-workflow-smoketest.md
@@ -2,4 +2,9 @@
 
 This file exists to trigger PR workflows and confirm Codex automation is running end-to-end.
 - Purpose: workflow health check only; no product impact.
-- Expected: PR assignee check, Codex review, Gemini review, Vercel preview (may fail if config incomplete), SonarCloud.
+- Expected:
+  - PR assignee check
+  - Codex review
+  - Gemini review
+  - Vercel preview (may fail if config incomplete)
+  - SonarCloud


### PR DESCRIPTION
Adds a no-op doc to trigger Codex/CI workflows and validate automation health.

## Summary by Sourcery

Add a documentation-only file to act as a Codex workflow smoke test without impacting product behavior.

Documentation:
- Add a Codex workflow smoke test doc explaining its purpose as a CI/automation health check.

Chores:
- Trigger Codex and CI workflows via a no-op documentation change to validate automation health.