### PR TITLE
chore: add GitHub Actions workflow for auto-closing stale PRs

### DIFF
--- a/.github/workflows/auto-close-stale-prs.yml
+++ b/.github/workflows/auto-close-stale-prs.yml
@@ -1,0 +1,29 @@
+name: Auto-close Stale PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs daily at midnight UTC
+  workflow_dispatch:
+
+jobs:
+  close-stale-prs:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Close stale PRs (5+ days inactive)
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: |
+            This PR has been inactive for 5 days. 
+            PR will be automatically closed.
+            To reopen, comment or push new changes.
+          close-pr-message: 'Auto-closed due to inactivity (5+ days)'
+          days-before-pr-stale: 5
+          days-before-pr-close: 0
+          # Exclude PRs with labels: do-not-close, important
+          exempt-pr-labels: 'do-not-close,important,blocked'
+          stale-pr-label: 'stale'
+          close-pr-label: 'auto-closed'
+          operations-per-run: 100


### PR DESCRIPTION
# Summary
- [ ] KPI impact: which KPIs/dashboards are affected? Link to `docs/analytics/KPIs.md`.
- [ ] Data sources touched: tables/contracts/migrations updated?
- [ ] Data/PII touched: list fields or confirm none; logging sanitized?
- [ ] Tests: unit/integration/e2e run? attach results.
- [ ] Security/compliance: secrets handled safely, PII masked, audit/logging impact noted.
- [ ] Env/alerts: required env vars set/updated (`NEXT_PUBLIC_ALERT_*`, webhooks, emails)?
- [ ] Runbooks/alerts: updated links or thresholds? next-best actions still valid?
- [ ] Workflow hygiene: PR assigned to `@codex` and reviewers `@sonarqube`, `@coderabbit`, `@sourcery` (auto-assignment workflow runs on open/update).

# Checklist
- [ ] CI passed (lint, type-check, tests, build for web/analytics).
- [ ] SonarCloud coverage/quality gate OK.
- [ ] CodeQL/secret scanning OK.
- [ ] Docs updated (dashboards, runbooks, compliance) if applicable.

## Summary by Sourcery

Build:
- Introduce a daily GitHub Actions workflow that uses actions/stale to label PRs as stale after 5 days of inactivity, auto-close them immediately thereafter, and exempt specified labels from auto-closing.