### PR TITLE
Add SWA deploy workflow and SPA fallback

### DIFF
--- a/.github/workflows/azure-static-web-apps-yellow-cliff-03015b20f.yml
+++ b/.github/workflows/azure-static-web-apps-yellow-cliff-03015b20f.yml
@@ -4,55 +4,57 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'apps/web/**'
+      - '.github/workflows/azure-static-web-apps-yellow-cliff-03015b20f.yml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - main
+    paths:
+      - 'apps/web/**'
+      - '.github/workflows/azure-static-web-apps-yellow-cliff-03015b20f.yml'
 
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
-    permissions:
-       id-token: write
-       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
-          lfs: false
-      - name: Install OIDC Client from Core Package
-        run: npm install @actions/core@1.6.0 @actions/http-client
-      - name: Get Id Token
-        uses: actions/github-script@v6
-        id: idtoken
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-           script: |
-               const coredemo = require('@actions/core')
-               return await coredemo.getIDToken()
-           result-encoding: string
-      - name: Build And Deploy
-        id: builddeploy
+          node-version: '20'
+      - name: Install
+        working-directory: apps/web
+        run: npm ci
+      - name: Build
+        working-directory: apps/web
+        run: npm run build
+      - name: Deploy
+        id: swa-deploy
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_YELLOW_CLIFF_03015B20F }}
-          action: "upload"
-          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
-          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "./apps" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "build" # Built app content directory - optional
-          github_id_token: ${{ steps.idtoken.outputs.result }}
-          ###### End of Repository/Build Configurations ######
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: apps/web
+          output_location: .next
+          api_location: ''
+          config_file_location: apps/web
+          skip_app_build: true
+          skip_api_build: true
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
-    name: Close Pull Request Job
+    name: Close Pull Request Environment
     steps:
-      - name: Close Pull Request
-        id: closepullrequest
+      - name: Close PR
         uses: Azure/static-web-apps-deploy@v1
         with:
-          action: "close"
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_YELLOW_CLIFF_03015B20F }}
+          action: close

--- a/apps/web/staticwebapp.config.json
+++ b/apps/web/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/api/*", "/static/*", "/_next/*"]
+  }
+}


### PR DESCRIPTION
Adds Azure Static Web Apps CI/CD workflow pointing at apps/web (.next output) and a navigationFallback config for SPA routing.

## Summary by Sourcery

Set up automated deployment of the web app to Azure Static Web Apps and add configuration to support SPA-style routing.

Enhancements:
- Add a Static Web Apps configuration file for the web app to enable SPA navigation fallback routing.

Build:
- Introduce an Azure Static Web Apps CI/CD GitHub Actions workflow that builds the apps/web project on pushes and pull requests and deploys the generated .next output.
- Add a job to clean up Azure Static Web Apps pull request environments when PRs are closed.