### PR TITLE
Fix IntegrationSettings export for SWA build

### DIFF
--- a/apps/web/src/components/integrations/index.ts
+++ b/apps/web/src/components/integrations/index.ts
@@ -1,5 +1,5 @@
 // Export main integration components for barrel import
-export { default as IntegrationSettings } from './IntegrationSettings';
+export { IntegrationSettings } from './IntegrationSettings';
 export { default as SlideShell } from './SlideShell';
 export { default as IntegrationCard } from './IntegrationCard';
 export { default as BulkTokenInput } from './BulkTokenInput';


### PR DESCRIPTION
Fixes Next.js build failure by exporting the named IntegrationSettings component (no default export).

## Summary by Sourcery

Bug Fixes:
- Resolve Next.js build failure caused by incorrect default export of IntegrationSettings from the integrations index barrel.