### PR TITLE
Fix integrations barrel exports

### DIFF
--- a/apps/web/src/components/integrations/index.ts
+++ b/apps/web/src/components/integrations/index.ts
@@ -1,10 +1,10 @@
 // Export main integration components for barrel import
 export { IntegrationSettings } from './IntegrationSettings';
-export { default as SlideShell } from './SlideShell';
-export { default as IntegrationCard } from './IntegrationCard';
-export { default as BulkTokenInput } from './BulkTokenInput';
-export { default as SlideLayout } from './SlideLayout';
-export { default as FluidBackground } from './FluidBackground';
+export { SlideShell } from './SlideShell';
+export { IntegrationCard } from './IntegrationCard';
+export { BulkTokenInput } from './BulkTokenInput';
+export { SlideLayout } from './SlideLayout';
+export { FluidBackground } from './FluidBackground';
 
 // Export types
 export type { StatusRow } from './IntegrationSettings';


### PR DESCRIPTION
Use named exports in integrations/index.ts to match component definitions and unblock Next.js build for SWA deploy.

## Summary by Sourcery

Bug Fixes:
- Align integrations barrel exports with component export style to fix import resolution issues in builds.