### PR TITLE
chore(deps): bump actions/setup-python to v6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup Python
         if: matrix.language == 'python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/coderabbit-ci.yml
+++ b/.github/workflows/coderabbit-ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install lint/security toolchain

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/model-evaluation.yml
+++ b/.github/workflows/model-evaluation.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'


### PR DESCRIPTION
## Summary
- bump actions/setup-python to v6 in CI workflows

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ee49874788333ac8309fd4358f2aa)

## Summary by Sourcery

Build:
- Bump actions/setup-python from v5 to v6 across CI workflows (CodeQL, CodeRabbit, Gemini PR review, and model evaluation).