### PR TITLE
chore(deps): bump actions/setup-java from 4 to 5

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'


### PR DESCRIPTION
## Summary
- bump SonarQube workflow to actions/setup-java v5

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ee4b00be4833386b41d4ca57496e0)

## Summary by Sourcery

CI:
- Bump actions/setup-java from v4 to v5 in the SonarQube analysis workflow.