### PR TITLE
chore: bump actions/setup-java to v5 in SonarQube workflow

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'


### PR DESCRIPTION
## Summary
- update SonarQube workflow to use actions/setup-java@v5 for JDK 21 setup
- keep other workflow steps unchanged

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ee42f8a2c8333a7fbfd037081d3ae)

## Summary by Sourcery

CI:
- Bump actions/setup-java from v4 to v5 in the SonarQube workflow while keeping the rest of the job unchanged.