### PR TITLE
chore(deps): bump SonarSource/sonarqube-scan-action from 6 to 7

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Clean build (Java 21)
         run: ./gradlew clean build --no-daemon
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
## Summary
- bump SonarSource/sonarqube-scan-action to v7 in the SonarQube workflow

## Testing
- not run (CI not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ee44d34048333abc77b5eaa0f9c4e)

## Summary by Sourcery

Build:
- Bump SonarSource/sonarqube-scan-action in the SonarQube workflow from v6 to v7.