### PR TITLE
chore(deps): bump pytest from 9.0.1 to 9.0.2 #250

### DIFF
--- a/apps/web/requirements.lock
+++ b/apps/web/requirements.lock
@@ -38,7 +38,7 @@ pycparser==2.23
 pydeck==0.9.1
 Pygments==2.19.2
 PyJWT==2.10.1
-pytest==9.0.1
+pytest==9.0.2
 pytest-cov==5.0.0
 python-dateutil==2.9.0.post0
 pytz==2025.2

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -40,7 +40,7 @@ pydeck==0.9.1
 Pygments==2.19.2
 PyJWT==2.10.1
 pytest-cov==5.0.0
-pytest==9.0.1
+pytest==9.0.2
 python-dateutil==2.9.0.post0
 pytz==2025.2
 PyYAML==6.0.3


### PR DESCRIPTION
## Summary
- bump pytest dependency to 9.0.2 in Python lockfiles to keep tooling up to date

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ee50b8ec88333858ca1b9eecea4f9)

## Summary by Sourcery

Build:
- Update pytest version to 9.0.2 in web app and root Python lockfiles to keep tooling current.