### PR TITLE
chore: bump tzdata to 2025.3

### DIFF
--- a/apps/web/requirements.lock
+++ b/apps/web/requirements.lock
@@ -55,5 +55,5 @@ threadpoolctl==3.6.0
 toml==0.10.2
 tornado==6.5.3
 typing_extensions==4.15.0
-tzdata==2025.2
+tzdata==2025.3
 urllib3==2.6.2

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -57,5 +57,5 @@ threadpoolctl==3.6.0
 toml==0.10.2
 tornado==6.5.3
 typing_extensions==4.15.0
-tzdata==2025.2
+tzdata==2025.3
 urllib3==2.6.2


### PR DESCRIPTION
## Summary
- bump tzdata dependency to version 2025.3 in root and web requirements locks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ee5bdb89c8333878405cdde53b1d2)

## Summary by Sourcery

Chores:
- Bump tzdata package version to 2025.3 in root and web requirements lock files.