### PR TITLE
Add Codex label and Gemini review assignment

### DIFF
--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -15,15 +15,18 @@ jobs:
             const prNumber = context.payload.pull_request.number;
             const repo = context.repo;
             const desiredAssignees = ['codex'];
-            const desiredReviewers = [];
+            const desiredReviewers = ['gemini'];
+            const desiredLabels = ['Codex'];
             const { data: pull } = await github.rest.pulls.get({
               ...repo,
               pull_number: prNumber,
             });
             const currentAssignees = pull.assignees.map(({ login }) => login);
             const currentReviewers = pull.requested_reviewers.map(({ login }) => login);
+            const currentLabels = pull.labels.map(({ name }) => name);
             const assigneesToAdd = desiredAssignees.filter((login) => !currentAssignees.includes(login));
             const reviewersToAdd = desiredReviewers.filter((login) => !currentReviewers.includes(login));
+            const labelsToAdd = desiredLabels.filter((name) => !currentLabels.includes(name));
             if (assigneesToAdd.length > 0) {
               await github.rest.issues.addAssignees({
                 ...repo,
@@ -36,5 +39,12 @@ jobs:
                 ...repo,
                 pull_number: prNumber,
                 reviewers: reviewersToAdd,
+              });
+            }
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                ...repo,
+                issue_number: prNumber,
+                labels: labelsToAdd,
               });
             }


### PR DESCRIPTION
## Summary
- request Gemini as a default reviewer for pull requests
- add the Codex label automatically when PRs are opened or updated

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f725cbac88333ae1084952403c9e5)

## Summary by Sourcery

Automatically assign Codex and request Gemini review on pull requests, and apply the Codex label when PRs are opened or updated.

New Features:
- Automatically request Gemini as a default reviewer on pull requests.
- Automatically apply the Codex label to pull requests when they are opened or updated.